### PR TITLE
Service Unit Tests

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -34,6 +34,6 @@
 **/README.md
 **/.env
 **/.env*
-**/test
+**/tests
 **/mutants.out*/
 **/*.log

--- a/README.md
+++ b/README.md
@@ -93,3 +93,11 @@ Visit http://localhost:8080/swagger-ui for complete interactive documentation wi
 - **Configurable CORS**: Cross-origin protection
 - **Input Validation**: Rigorous validation of all inputs
 - **Error Handling**: Secure error handling without information leakage
+
+## Testing
+
+Run the tests locally:
+
+```bash
+cargo test -- --nocapture
+```

--- a/src/app/state.rs
+++ b/src/app/state.rs
@@ -5,13 +5,14 @@ use redis::aio::ConnectionManager;
 use webauthn_rs::Webauthn;
 
 use crate::{
-    auth::{repo::AuthRepository, service::AuthService},
+    auth::{repo::Repository, service::AuthService},
     config::origin::OriginConfig,
-    utils::{cookie::CookieService, jwt::JwtService},
+    utils::{cookie::CookieService, jwt::Jwt},
 };
 
+pub type Service = AuthService<Repository, Jwt>;
 pub struct AppState {
-    pub auth_service: Arc<AuthService>,
+    pub auth_service: Arc<Service>,
     pub cookie_service: Arc<CookieService>,
 }
 
@@ -22,8 +23,8 @@ impl AppState {
         redis_manager: ConnectionManager,
         origin_config: OriginConfig,
     ) -> Arc<Self> {
-        let user_repo = Arc::new(AuthRepository::new(db));
-        let jwt_service = Arc::new(JwtService::new(redis_manager));
+        let user_repo = Arc::new(Repository::new(db));
+        let jwt_service = Arc::new(Jwt::new(redis_manager));
         let auth_service = Arc::new(AuthService::new(webauthn, user_repo, jwt_service));
         let cookie_service = Arc::new(CookieService::new(&origin_config));
 

--- a/src/auth/mod.rs
+++ b/src/auth/mod.rs
@@ -3,3 +3,4 @@ pub mod handler;
 pub mod model;
 pub mod repo;
 pub mod service;
+pub mod traits;

--- a/src/auth/repo.rs
+++ b/src/auth/repo.rs
@@ -7,204 +7,18 @@ use crate::{
     auth::{
         dto::response::ServiceHealth,
         model::{User, WebAuthnSession},
+        traits::AuthRepository,
     },
     utils::health::check_database_health,
 };
 
-pub struct AuthRepository {
+pub struct Repository {
     db: Pool,
 }
 
-impl AuthRepository {
+impl Repository {
     pub fn new(db: Pool) -> Self {
         Self { db }
-    }
-
-    pub async fn check_db(&self) -> ServiceHealth {
-        check_database_health(|| async {
-            let client = &self.db.get().await?;
-            client.query_one("SELECT 1 as health_check", &[]).await?;
-            Ok(())
-        })
-        .await
-    }
-
-    pub async fn create_user(&self, username: &str, role: Option<&str>) -> Result<User, AppError> {
-        let client = &self.db.get().await?;
-
-        match self.get_user_by_username(&username).await {
-            Ok(user) => {
-                if user.status == "active" {
-                    return Err(AppError::AlreadyExists(String::from(
-                        "Username already exists",
-                    )));
-                } else {
-                    return Ok(user);
-                }
-            }
-            Err(AppError::NotFound(_)) => {}
-            Err(e) => return Err(e),
-        }
-
-        let row = if let Some(i) = role {
-            client
-                .query_one(
-                    "INSERT INTO users (username, role) VALUES ($1, $2) RETURNING *",
-                    &[&username, &i],
-                )
-                .await?
-        } else {
-            client
-                .query_one(
-                    "INSERT INTO users (username) VALUES ($1) RETURNING *",
-                    &[&username],
-                )
-                .await?
-        };
-
-        Self::row_to_user(&row)
-    }
-
-    pub async fn get_user_by_username(&self, username: &str) -> Result<User, AppError> {
-        let client = &self.db.get().await?;
-
-        match client
-            .query_opt("SELECT * FROM users WHERE username = $1", &[&username])
-            .await?
-        {
-            Some(row) => Self::row_to_user(&row),
-            None => Err(AppError::NotFound(String::from("Username not found"))),
-        }
-    }
-
-    pub async fn get_user_and_session(
-        &self,
-        session_id: Uuid,
-        username: &str,
-        purpose: &str,
-    ) -> Result<(User, WebAuthnSession), AppError> {
-        let client = &self.db.get().await?;
-
-        match client
-            .query_opt(
-                "SELECT
-                        u.id, u.username, u.role, u.status, u.created_at, u.updated_at, u.is_active,
-                        ws.id as session_id, ws.user_id, ws.data, ws.purpose,
-                        ws.created_at as session_created_at, ws.expires_at
-                     FROM users u
-                     INNER JOIN webauthn_sessions ws ON u.id = ws.user_id
-                     WHERE u.username = $1 AND ws.id = $2 AND ws.purpose = $3",
-                &[&username, &session_id, &purpose],
-            )
-            .await?
-        {
-            Some(row) => {
-                let user = Self::row_to_user(&row)?;
-                let session = Self::row_to_webauthn_session(&row)?;
-                Ok((user, session))
-            }
-            None => Err(AppError::NotFound(String::from(
-                "User or session not found",
-            ))),
-        }
-    }
-
-    pub async fn get_active_user_with_credential(
-        &self,
-        username: &str,
-    ) -> Result<(User, Vec<webauthn_rs::prelude::Passkey>), AppError> {
-        let client = &self.db.get().await?;
-
-        let rows = client
-            .query(
-                "SELECT
-                        u.id, u.username, u.role, u.status, u.created_at, u.updated_at, u.is_active,
-                        c.passkey
-                     FROM users u
-                     INNER JOIN credentials c ON u.id = c.user_id
-                     WHERE u.username = $1 AND u.status = 'active'",
-                &[&username],
-            )
-            .await?;
-
-        if rows.is_empty() {
-            return Err(AppError::NotFound(String::from(
-                "User or credentials not found",
-            )));
-        }
-
-        let user = Self::row_to_user(&rows[0])?;
-        let mut passkeys = Vec::new();
-        for row in rows {
-            let passkey_json: serde_json::Value = row.try_get("passkey")?;
-            let passkey: webauthn_rs::prelude::Passkey = serde_json::from_value(passkey_json)?;
-            passkeys.push(passkey);
-        }
-
-        Ok((user, passkeys))
-    }
-
-    pub async fn create_webauthn_session(
-        &self,
-        user_id: Uuid,
-        data: serde_json::Value,
-        purpose: &str,
-    ) -> Result<Uuid, AppError> {
-        let client = &self.db.get().await?;
-        let expire_at = Utc::now() + chrono::Duration::minutes(30);
-
-        let row = client.query_one(
-                "INSERT INTO webauthn_sessions (user_id, data, purpose, expires_at) VALUES ($1, $2, $3, $4) RETURNING id",
-                &[&user_id, &data, &purpose, &expire_at],
-            )
-            .await?;
-
-        Ok(row.get("id"))
-    }
-
-    pub async fn delete_webauthn_session(&self, id: Uuid) -> Result<(), AppError> {
-        let client = &self.db.get().await?;
-
-        client
-            .execute("DELETE FROM webauthn_sessions WHERE id = $1", &[&id])
-            .await?;
-
-        Ok(())
-    }
-
-    pub async fn update_credential(
-        &self,
-        cred_id: &[u8],
-        new_counter: u32,
-    ) -> Result<(), AppError> {
-        let client = &self.db.get().await?;
-
-        client
-            .execute(
-                "UPDATE credentials
-                    SET passkey = jsonb_set(passkey, '{counter}', $1::text::jsonb)
-                    WHERE id = $2",
-                &[&(new_counter as i64), &cred_id],
-            )
-            .await?;
-
-        Ok(())
-    }
-
-    pub async fn complete_registration(
-        &self,
-        user_id: Uuid,
-        username: &str,
-        passkey: &webauthn_rs::prelude::Passkey,
-    ) -> Result<(), AppError> {
-        let mut client = self.db.get().await?;
-        let tx = client.transaction().await?;
-
-        self.create_credential(&tx, user_id, passkey).await?;
-        self.activate_user(&tx, username).await?;
-
-        tx.commit().await?;
-        Ok(())
     }
 
     async fn activate_user(&self, tx: &Transaction<'_>, username: &str) -> Result<(), AppError> {
@@ -255,5 +69,190 @@ impl AuthRepository {
             created_at: row.try_get("created_at")?,
             expires_at: row.try_get("expires_at")?,
         })
+    }
+}
+
+impl AuthRepository for Repository {
+    async fn check_db(&self) -> ServiceHealth {
+        check_database_health(|| async {
+            let client = &self.db.get().await?;
+            client.query_one("SELECT 1 as health_check", &[]).await?;
+            Ok(())
+        })
+        .await
+    }
+
+    async fn create_user(&self, username: &str, role: Option<&str>) -> Result<User, AppError> {
+        let client = &self.db.get().await?;
+
+        match self.get_user_by_username(&username).await {
+            Ok(user) => {
+                if user.status == "active" {
+                    return Err(AppError::AlreadyExists(String::from(
+                        "Username already exists",
+                    )));
+                } else {
+                    return Ok(user);
+                }
+            }
+            Err(AppError::NotFound(_)) => {}
+            Err(e) => return Err(e),
+        }
+
+        let row = if let Some(i) = role {
+            client
+                .query_one(
+                    "INSERT INTO users (username, role) VALUES ($1, $2) RETURNING *",
+                    &[&username, &i],
+                )
+                .await?
+        } else {
+            client
+                .query_one(
+                    "INSERT INTO users (username) VALUES ($1) RETURNING *",
+                    &[&username],
+                )
+                .await?
+        };
+
+        Self::row_to_user(&row)
+    }
+
+    async fn get_user_by_username(&self, username: &str) -> Result<User, AppError> {
+        let client = &self.db.get().await?;
+
+        match client
+            .query_opt("SELECT * FROM users WHERE username = $1", &[&username])
+            .await?
+        {
+            Some(row) => Self::row_to_user(&row),
+            None => Err(AppError::NotFound(String::from("Username not found"))),
+        }
+    }
+
+    async fn get_user_and_session(
+        &self,
+        session_id: Uuid,
+        username: &str,
+        purpose: &str,
+    ) -> Result<(User, WebAuthnSession), AppError> {
+        let client = &self.db.get().await?;
+
+        match client
+            .query_opt(
+                "SELECT
+                        u.id, u.username, u.role, u.status, u.created_at, u.updated_at, u.is_active,
+                        ws.id as session_id, ws.user_id, ws.data, ws.purpose,
+                        ws.created_at as session_created_at, ws.expires_at
+                     FROM users u
+                     INNER JOIN webauthn_sessions ws ON u.id = ws.user_id
+                     WHERE u.username = $1 AND ws.id = $2 AND ws.purpose = $3",
+                &[&username, &session_id, &purpose],
+            )
+            .await?
+        {
+            Some(row) => {
+                let user = Self::row_to_user(&row)?;
+                let session = Self::row_to_webauthn_session(&row)?;
+                Ok((user, session))
+            }
+            None => Err(AppError::NotFound(String::from(
+                "User or session not found",
+            ))),
+        }
+    }
+
+    async fn get_active_user_with_credential(
+        &self,
+        username: &str,
+    ) -> Result<(User, Vec<webauthn_rs::prelude::Passkey>), AppError> {
+        let client = &self.db.get().await?;
+
+        let rows = client
+            .query(
+                "SELECT
+                        u.id, u.username, u.role, u.status, u.created_at, u.updated_at, u.is_active,
+                        c.passkey
+                     FROM users u
+                     INNER JOIN credentials c ON u.id = c.user_id
+                     WHERE u.username = $1 AND u.status = 'active'",
+                &[&username],
+            )
+            .await?;
+
+        if rows.is_empty() {
+            return Err(AppError::NotFound(String::from(
+                "User or credentials not found",
+            )));
+        }
+
+        let user = Self::row_to_user(&rows[0])?;
+        let mut passkeys = Vec::new();
+        for row in rows {
+            let passkey_json: serde_json::Value = row.try_get("passkey")?;
+            let passkey: webauthn_rs::prelude::Passkey = serde_json::from_value(passkey_json)?;
+            passkeys.push(passkey);
+        }
+
+        Ok((user, passkeys))
+    }
+
+    async fn create_webauthn_session(
+        &self,
+        user_id: Uuid,
+        data: serde_json::Value,
+        purpose: &str,
+    ) -> Result<Uuid, AppError> {
+        let client = &self.db.get().await?;
+        let expire_at = Utc::now() + chrono::Duration::minutes(30);
+
+        let row = client.query_one(
+                "INSERT INTO webauthn_sessions (user_id, data, purpose, expires_at) VALUES ($1, $2, $3, $4) RETURNING id",
+                &[&user_id, &data, &purpose, &expire_at],
+            )
+            .await?;
+
+        Ok(row.get("id"))
+    }
+
+    async fn delete_webauthn_session(&self, id: Uuid) -> Result<(), AppError> {
+        let client = &self.db.get().await?;
+
+        client
+            .execute("DELETE FROM webauthn_sessions WHERE id = $1", &[&id])
+            .await?;
+
+        Ok(())
+    }
+
+    async fn update_credential(&self, cred_id: &[u8], new_counter: u32) -> Result<(), AppError> {
+        let client = &self.db.get().await?;
+
+        client
+            .execute(
+                "UPDATE credentials
+                    SET passkey = jsonb_set(passkey, '{counter}', $1::text::jsonb)
+                    WHERE id = $2",
+                &[&(new_counter as i64), &cred_id],
+            )
+            .await?;
+
+        Ok(())
+    }
+
+    async fn complete_registration(
+        &self,
+        user_id: Uuid,
+        username: &str,
+        passkey: &webauthn_rs::prelude::Passkey,
+    ) -> Result<(), AppError> {
+        let mut client = self.db.get().await?;
+        let tx = client.transaction().await?;
+
+        self.create_credential(&tx, user_id, passkey).await?;
+        self.activate_user(&tx, username).await?;
+
+        tx.commit().await?;
+        Ok(())
     }
 }

--- a/src/auth/traits.rs
+++ b/src/auth/traits.rs
@@ -1,0 +1,77 @@
+use std::future::Future;
+use uuid::Uuid;
+use webauthn_rs::prelude::Passkey;
+
+use crate::{
+    app::AppError,
+    auth::{
+        dto::response::ServiceHealth,
+        model::{User, WebAuthnSession},
+    },
+    utils::jwt::TokenClaims,
+};
+
+pub trait AuthRepository: Send + Sync {
+    fn check_db(&self) -> impl Future<Output = ServiceHealth> + Send;
+    fn create_user(
+        &self,
+        username: &str,
+        role: Option<&str>,
+    ) -> impl Future<Output = Result<User, AppError>> + Send;
+    fn get_user_by_username(
+        &self,
+        username: &str,
+    ) -> impl Future<Output = Result<User, AppError>> + Send;
+    fn get_user_and_session(
+        &self,
+        session_id: Uuid,
+        username: &str,
+        purpose: &str,
+    ) -> impl Future<Output = Result<(User, WebAuthnSession), AppError>> + Send;
+    fn get_active_user_with_credential(
+        &self,
+        username: &str,
+    ) -> impl Future<Output = Result<(User, Vec<Passkey>), AppError>> + Send;
+    fn create_webauthn_session(
+        &self,
+        user_id: Uuid,
+        data: serde_json::Value,
+        purpose: &str,
+    ) -> impl Future<Output = Result<Uuid, AppError>> + Send;
+    fn delete_webauthn_session(
+        &self,
+        id: Uuid,
+    ) -> impl Future<Output = Result<(), AppError>> + Send;
+    fn update_credential(
+        &self,
+        cred_id: &[u8],
+        new_counter: u32,
+    ) -> impl Future<Output = Result<(), AppError>> + Send;
+    fn complete_registration(
+        &self,
+        user_id: Uuid,
+        username: &str,
+        passkey: &Passkey,
+    ) -> impl Future<Output = Result<(), AppError>> + Send;
+}
+
+pub trait JwtService: Send + Sync {
+    fn get_public_key_base64(&self) -> String;
+    fn check_redis(&self) -> impl Future<Output = ServiceHealth> + Send;
+    fn generate_token_pair(
+        &self,
+        user_id: Uuid,
+        username: &str,
+        role: Option<&str>,
+    ) -> crate::utils::jwt::TokenPair;
+    fn validate_refresh(
+        &self,
+        token: &str,
+    ) -> impl Future<Output = Result<TokenClaims, AppError>> + Send;
+    fn validate_access(
+        &self,
+        token: &str,
+    ) -> impl Future<Output = Result<TokenClaims, AppError>> + Send;
+    fn blacklist(&self, jti: &str, exp: i64) -> impl Future<Output = Result<(), AppError>> + Send;
+    fn is_blacklisted(&self, jti: &str) -> impl Future<Output = Result<bool, AppError>> + Send;
+}

--- a/tests/common/constants.rs
+++ b/tests/common/constants.rs
@@ -59,6 +59,6 @@ pub mod responses {
 pub mod test_data {
     pub const DEFAULT_USERNAME: &str = "test_user";
     pub const DEFAULT_ROLE: &str = "user";
-    pub const WEBAUTHN_ORIGIN: &str = "https://localhost:8080";
+    pub const WEBAUTHN_ORIGIN: &str = "http://localhost:3000";
     pub const WEBAUTHN_RP_NAME: &str = "localhost";
 }

--- a/tests/common/constants.rs
+++ b/tests/common/constants.rs
@@ -6,7 +6,6 @@ pub mod triggers {
     pub const USER_NOT_FOUND: &str = "user_not_found";
     pub const SESSION_NOT_FOUND: &str = "session_not_found";
     pub const NO_CREDENTIALS: &str = "no_credentials";
-    pub const REGISTRATION_FAILED: &str = "registration_failed";
 
     pub const INVALID_TOKEN: &str = "invalid_token";
     pub const EXPIRED_TOKEN: &str = "expired_token";

--- a/tests/common/constants.rs
+++ b/tests/common/constants.rs
@@ -1,0 +1,64 @@
+pub mod triggers {
+    pub const USER_ALREADY_EXISTS: &str = "user_already_exists";
+    pub const DB_ERROR: &str = "db_error";
+    pub const INVALID_USERNAME: &str = "invalid_username";
+    pub const SERVICE_DOWN: &str = "service_down";
+    pub const USER_NOT_FOUND: &str = "user_not_found";
+    pub const SESSION_NOT_FOUND: &str = "session_not_found";
+    pub const NO_CREDENTIALS: &str = "no_credentials";
+    pub const REGISTRATION_FAILED: &str = "registration_failed";
+
+    pub const INVALID_TOKEN: &str = "invalid_token";
+    pub const EXPIRED_TOKEN: &str = "expired_token";
+    pub const MALFORMED_TOKEN: &str = "malformed_token";
+    pub const BLACKLISTED_TOKEN: &str = "blacklisted_token";
+    pub const REDIS_ERROR: &str = "redis_error";
+    pub const BLACKLISTED_JTI: &str = "blacklisted_jti";
+
+    pub const SESSION_CREATION_ERROR_UUID: &str = "00000000-0000-0000-0000-000000000001";
+    pub const SERVICE_UNAVAILABLE_UUID: &str = "00000000-0000-0000-0000-000000000002";
+    pub const SESSION_NOT_FOUND_UUID: &str = "00000000-0000-0000-0000-000000000404";
+
+    pub const ERROR_CRED_ID: &[u8] = b"error_cred_id";
+    pub const DB_ERROR_CRED_ID: &[u8] = b"db_error";
+}
+
+pub mod messages {
+    pub const USER_ALREADY_EXISTS: &str = "User already exists";
+    pub const DB_CONNECTION_FAILED: &str = "Database connection failed";
+    pub const INVALID_USERNAME_FORMAT: &str = "Invalid username format";
+    pub const DB_SERVICE_DOWN: &str = "Database service is down";
+    pub const USER_NOT_FOUND: &str = "User not found";
+    pub const SESSION_NOT_FOUND: &str = "Session not found";
+    pub const NO_CREDENTIALS_FOUND: &str = "No credentials found";
+    pub const SESSION_CREATION_FAILED: &str = "Session creation failed";
+    pub const REGISTRATION_FAILED: &str = "Registration failed";
+    pub const DB_ERROR: &str = "Database error";
+    pub const CREDENTIAL_NOT_FOUND: &str = "Credential not found";
+
+    pub const INVALID_REFRESH_TOKEN: &str = "Invalid refresh token";
+    pub const INVALID_ACCESS_TOKEN: &str = "Invalid access token";
+    pub const TOKEN_EXPIRED: &str = "Token expired";
+    pub const TOKEN_BLACKLISTED: &str = "Token is blacklisted";
+    pub const MALFORMED_TOKEN: &str = "Malformed token";
+    pub const REDIS_CONNECTION_FAILED: &str = "Redis connection failed";
+    pub const REDIS_SERVICE_DOWN: &str = "Redis service is down";
+}
+
+pub mod responses {
+    pub const MOCK_PUBLIC_KEY: &str = "mock_public_key";
+    pub const MOCK_ACCESS_TOKEN: &str = "mock_access_token";
+    pub const MOCK_REFRESH_TOKEN: &str = "mock_refresh_token";
+    pub const MOCK_JTI: &str = "mock_jti";
+    pub const MOCK_SESSION_UUID: &str = "12345678-1234-1234-1234-123456789def";
+    pub const HEALTHY_STATUS_OK: &str = "OK";
+    pub const DB_RESPONSE_TIME_MS: u64 = 100;
+    pub const REDIS_RESPONSE_TIME_MS: u64 = 30;
+}
+
+pub mod test_data {
+    pub const DEFAULT_USERNAME: &str = "test_user";
+    pub const DEFAULT_ROLE: &str = "user";
+    pub const WEBAUTHN_ORIGIN: &str = "https://localhost:8080";
+    pub const WEBAUTHN_RP_NAME: &str = "localhost";
+}

--- a/tests/common/constants.rs
+++ b/tests/common/constants.rs
@@ -17,9 +17,6 @@ pub mod triggers {
     pub const SESSION_CREATION_ERROR_UUID: &str = "00000000-0000-0000-0000-000000000001";
     pub const SERVICE_UNAVAILABLE_UUID: &str = "00000000-0000-0000-0000-000000000002";
     pub const SESSION_NOT_FOUND_UUID: &str = "00000000-0000-0000-0000-000000000404";
-
-    pub const ERROR_CRED_ID: &[u8] = b"error_cred_id";
-    pub const DB_ERROR_CRED_ID: &[u8] = b"db_error";
 }
 
 pub mod messages {
@@ -31,9 +28,6 @@ pub mod messages {
     pub const SESSION_NOT_FOUND: &str = "Session not found";
     pub const NO_CREDENTIALS_FOUND: &str = "No credentials found";
     pub const SESSION_CREATION_FAILED: &str = "Session creation failed";
-    pub const REGISTRATION_FAILED: &str = "Registration failed";
-    pub const DB_ERROR: &str = "Database error";
-    pub const CREDENTIAL_NOT_FOUND: &str = "Credential not found";
 
     pub const INVALID_REFRESH_TOKEN: &str = "Invalid refresh token";
     pub const INVALID_ACCESS_TOKEN: &str = "Invalid access token";
@@ -53,11 +47,22 @@ pub mod responses {
     pub const HEALTHY_STATUS_OK: &str = "OK";
     pub const DB_RESPONSE_TIME_MS: u64 = 100;
     pub const REDIS_RESPONSE_TIME_MS: u64 = 30;
+
+    pub const REGISTRATION_SUCCESS: &str = "Registration completed successfully!";
+    pub const LOGIN_SUCCESS: &str = "Login completed successfully!";
+    pub const REFRESH_SUCCESS: &str = "Refresh completed successfully!";
+    pub const LOGOUT_SUCCESS: &str = "Logout completed successfully!";
 }
 
 pub mod test_data {
     pub const DEFAULT_USERNAME: &str = "test_user";
     pub const DEFAULT_ROLE: &str = "user";
+    pub const USER_STATUS_ACTIVE: &str = "active";
     pub const WEBAUTHN_ORIGIN: &str = "http://localhost:3000";
     pub const WEBAUTHN_RP_NAME: &str = "localhost";
+    pub const DEFAULT_USER_UUID: &str = "12345678-1234-1234-1234-123456789abc";
+    pub const REFRESH_USER_UUID: &str = "12345678-1234-1234-1234-123456789aaa";
+    pub const ACCESS_USER_UUID: &str = "12345678-1234-1234-1234-123456789bbb";
+    pub const LOGIN_SESSION_PURPOSE: &str = "login";
+    pub const REGISTRATION_SESSION_PURPOSE: &str = "registration";
 }

--- a/tests/common/fixture.rs
+++ b/tests/common/fixture.rs
@@ -46,7 +46,7 @@ pub fn mock_login_session() -> WebAuthnSession {
 
 pub fn mock_access_claims() -> TokenClaims {
     TokenClaims {
-        sub: Uuid::parse_str("12345678-1234-1234-1234-123456789ghi").unwrap(),
+        sub: Uuid::parse_str("12345678-1234-1234-1234-123456789bbb").unwrap(),
         username: DEFAULT_USERNAME.to_string(),
         role: Some(DEFAULT_ROLE.to_string()),
         exp: chrono::Utc::now().timestamp() + 900,
@@ -57,7 +57,7 @@ pub fn mock_access_claims() -> TokenClaims {
 
 pub fn mock_refresh_claims() -> TokenClaims {
     TokenClaims {
-        sub: Uuid::parse_str("12345678-1234-1234-1234-123456789llm").unwrap(),
+        sub: Uuid::parse_str("12345678-1234-1234-1234-123456789aaa").unwrap(),
         username: DEFAULT_USERNAME.to_string(),
         role: Some(DEFAULT_ROLE.to_string()),
         exp: chrono::Utc::now().timestamp() + 3600,

--- a/tests/common/fixture.rs
+++ b/tests/common/fixture.rs
@@ -1,0 +1,51 @@
+use chrono::Utc;
+use rs_passkey_auth::{
+    auth::model::{User, WebAuthnSession},
+    utils::jwt::TokenClaims,
+};
+use uuid::Uuid;
+
+pub fn mock_user() -> User {
+    User {
+        id: Uuid::parse_str("12345678-1234-1234-1234-123456789abc").unwrap(),
+        username: "test_user".to_string(),
+        role: Some("user".to_string()),
+        status: "active".to_string(),
+        created_at: Utc::now(),
+        updated_at: Utc::now(),
+        is_active: true,
+    }
+}
+
+pub fn mock_session() -> WebAuthnSession {
+    WebAuthnSession {
+        id: Uuid::parse_str("12345678-1234-1234-1234-123456789def").unwrap(),
+        user_id: Uuid::parse_str("12345678-1234-1234-1234-123456789abc").unwrap(),
+        data: serde_json::json!({}),
+        purpose: "registration".to_string(),
+        created_at: Utc::now(),
+        expires_at: Utc::now() + chrono::Duration::minutes(10),
+    }
+}
+
+pub fn mock_access_claims() -> TokenClaims {
+    TokenClaims {
+        sub: Uuid::parse_str("12345678-1234-1234-1234-123456789ghi").unwrap(),
+        username: "test_user".to_string(),
+        role: Some("user".to_string()),
+        exp: chrono::Utc::now().timestamp() + 900,
+        iat: chrono::Utc::now().timestamp(),
+        jti: None,
+    }
+}
+
+pub fn mock_refresh_claims() -> TokenClaims {
+    TokenClaims {
+        sub: Uuid::parse_str("12345678-1234-1234-1234-123456789llm").unwrap(),
+        username: "test_user".to_string(),
+        role: Some("user".to_string()),
+        exp: chrono::Utc::now().timestamp() + 3600,
+        iat: chrono::Utc::now().timestamp(),
+        jti: Some("mock_jti".to_string()),
+    }
+}

--- a/tests/common/fixture.rs
+++ b/tests/common/fixture.rs
@@ -7,15 +7,18 @@ use uuid::Uuid;
 
 use crate::common::constants::{
     responses::{MOCK_JTI, MOCK_SESSION_UUID},
-    test_data::{DEFAULT_ROLE, DEFAULT_USERNAME},
+    test_data::{
+        ACCESS_USER_UUID, DEFAULT_ROLE, DEFAULT_USER_UUID, DEFAULT_USERNAME, LOGIN_SESSION_PURPOSE,
+        REFRESH_USER_UUID, REGISTRATION_SESSION_PURPOSE, USER_STATUS_ACTIVE,
+    },
 };
 
 pub fn mock_user() -> User {
     User {
-        id: Uuid::parse_str("12345678-1234-1234-1234-123456789abc").unwrap(),
+        id: Uuid::parse_str(DEFAULT_USER_UUID).unwrap(),
         username: DEFAULT_USERNAME.to_string(),
         role: Some(DEFAULT_ROLE.to_string()),
-        status: "active".to_string(),
+        status: USER_STATUS_ACTIVE.to_string(),
         created_at: Utc::now(),
         updated_at: Utc::now(),
         is_active: true,
@@ -25,9 +28,9 @@ pub fn mock_user() -> User {
 pub fn mock_register_session() -> WebAuthnSession {
     WebAuthnSession {
         id: Uuid::parse_str(MOCK_SESSION_UUID).unwrap(),
-        user_id: Uuid::parse_str("12345678-1234-1234-1234-123456789abc").unwrap(),
+        user_id: Uuid::parse_str(DEFAULT_USER_UUID).unwrap(),
         data: mock_register_session_data(),
-        purpose: "registration".to_string(),
+        purpose: REGISTRATION_SESSION_PURPOSE.to_string(),
         created_at: Utc::now(),
         expires_at: Utc::now() + chrono::Duration::minutes(10),
     }
@@ -36,9 +39,9 @@ pub fn mock_register_session() -> WebAuthnSession {
 pub fn mock_login_session() -> WebAuthnSession {
     WebAuthnSession {
         id: Uuid::parse_str(MOCK_SESSION_UUID).unwrap(),
-        user_id: Uuid::parse_str("12345678-1234-1234-1234-123456789abc").unwrap(),
+        user_id: Uuid::parse_str(DEFAULT_USER_UUID).unwrap(),
         data: mock_login_session_data(),
-        purpose: "login".to_string(),
+        purpose: LOGIN_SESSION_PURPOSE.to_string(),
         created_at: Utc::now(),
         expires_at: Utc::now() + chrono::Duration::minutes(10),
     }
@@ -46,7 +49,7 @@ pub fn mock_login_session() -> WebAuthnSession {
 
 pub fn mock_access_claims() -> TokenClaims {
     TokenClaims {
-        sub: Uuid::parse_str("12345678-1234-1234-1234-123456789bbb").unwrap(),
+        sub: Uuid::parse_str(ACCESS_USER_UUID).unwrap(),
         username: DEFAULT_USERNAME.to_string(),
         role: Some(DEFAULT_ROLE.to_string()),
         exp: chrono::Utc::now().timestamp() + 900,
@@ -57,7 +60,7 @@ pub fn mock_access_claims() -> TokenClaims {
 
 pub fn mock_refresh_claims() -> TokenClaims {
     TokenClaims {
-        sub: Uuid::parse_str("12345678-1234-1234-1234-123456789aaa").unwrap(),
+        sub: Uuid::parse_str(REFRESH_USER_UUID).unwrap(),
         username: DEFAULT_USERNAME.to_string(),
         role: Some(DEFAULT_ROLE.to_string()),
         exp: chrono::Utc::now().timestamp() + 3600,

--- a/tests/common/fixture.rs
+++ b/tests/common/fixture.rs
@@ -5,11 +5,16 @@ use rs_passkey_auth::{
 };
 use uuid::Uuid;
 
+use crate::common::constants::{
+    responses::{MOCK_JTI, MOCK_SESSION_UUID},
+    test_data::{DEFAULT_ROLE, DEFAULT_USERNAME},
+};
+
 pub fn mock_user() -> User {
     User {
         id: Uuid::parse_str("12345678-1234-1234-1234-123456789abc").unwrap(),
-        username: "test_user".to_string(),
-        role: Some("user".to_string()),
+        username: DEFAULT_USERNAME.to_string(),
+        role: Some(DEFAULT_ROLE.to_string()),
         status: "active".to_string(),
         created_at: Utc::now(),
         updated_at: Utc::now(),
@@ -19,9 +24,9 @@ pub fn mock_user() -> User {
 
 pub fn mock_session() -> WebAuthnSession {
     WebAuthnSession {
-        id: Uuid::parse_str("12345678-1234-1234-1234-123456789def").unwrap(),
+        id: Uuid::parse_str(MOCK_SESSION_UUID).unwrap(),
         user_id: Uuid::parse_str("12345678-1234-1234-1234-123456789abc").unwrap(),
-        data: serde_json::json!({}),
+        data: mock_session_data(),
         purpose: "registration".to_string(),
         created_at: Utc::now(),
         expires_at: Utc::now() + chrono::Duration::minutes(10),
@@ -31,8 +36,8 @@ pub fn mock_session() -> WebAuthnSession {
 pub fn mock_access_claims() -> TokenClaims {
     TokenClaims {
         sub: Uuid::parse_str("12345678-1234-1234-1234-123456789ghi").unwrap(),
-        username: "test_user".to_string(),
-        role: Some("user".to_string()),
+        username: DEFAULT_USERNAME.to_string(),
+        role: Some(DEFAULT_ROLE.to_string()),
         exp: chrono::Utc::now().timestamp() + 900,
         iat: chrono::Utc::now().timestamp(),
         jti: None,
@@ -42,10 +47,42 @@ pub fn mock_access_claims() -> TokenClaims {
 pub fn mock_refresh_claims() -> TokenClaims {
     TokenClaims {
         sub: Uuid::parse_str("12345678-1234-1234-1234-123456789llm").unwrap(),
-        username: "test_user".to_string(),
-        role: Some("user".to_string()),
+        username: DEFAULT_USERNAME.to_string(),
+        role: Some(DEFAULT_ROLE.to_string()),
         exp: chrono::Utc::now().timestamp() + 3600,
         iat: chrono::Utc::now().timestamp(),
-        jti: Some("mock_jti".to_string()),
+        jti: Some(MOCK_JTI.to_string()),
     }
+}
+
+pub fn mock_credentials() -> serde_json::Value {
+    serde_json::json!({
+        "id": "ddqKTpT0rDW9bZGpVsNlC9gRYwA",
+        "rawId": "ddqKTpT0rDW9bZGpVsNlC9gRYwA",
+        "response": {
+            "attestationObject": "o2NmbXRkbm9uZWdhdHRTdG10oGhhdXRoRGF0YViYSZYN5YgOjGh0NBcPZHZgW4_krrmihjLHmVzzuoMdl2NdAAAAAPv8MAcVTk7MjAtuAgVX170AFHXaik6U9Kw1vW2RqVbDZQvYEWMApQECAyYgASFYICAcVADw5swzcjOny64uSpURBf5KTk0OtLBXw88XnebuIlggLg6ITKTw0skZ47_EdBA7A7TU6ihL61TwSgKyMRyaChE",
+            "clientDataJSON": "eyJ0eXBlIjoid2ViYXV0aG4uY3JlYXRlIiwiY2hhbGxlbmdlIjoiVnpyTF94cXdqelU0M0EwN2VVR2JYVThJYXJKcVUybFM4OXRJZzV2ZmQxYyIsIm9yaWdpbiI6Imh0dHA6Ly9sb2NhbGhvc3Q6MzAwMCIsImNyb3NzT3JpZ2luIjpmYWxzZX0"
+        },
+        "type": "public-key"
+    })
+}
+
+fn mock_session_data() -> serde_json::Value {
+    serde_json::json!({
+        "rs": {
+            "allow_synchronised_authenticators": true,
+            "authenticator_attachment": null,
+            "challenge": "VzrL_xqwjzU43A07eUGbXU8IarJqU2lS89tIg5vfd1c",
+            "credential_algorithms": ["ES256", "RS256"],
+            "exclude_credentials": [],
+            "extensions": {
+                "credProps": true,
+                "credentialProtectionPolicy": "userVerificationRequired",
+                "enforceCredentialProtectionPolicy": false,
+                "uvm": true
+            },
+            "policy": "required",
+            "require_resident_key": false
+        }
+    })
 }

--- a/tests/common/fixture.rs
+++ b/tests/common/fixture.rs
@@ -22,12 +22,23 @@ pub fn mock_user() -> User {
     }
 }
 
-pub fn mock_session() -> WebAuthnSession {
+pub fn mock_register_session() -> WebAuthnSession {
     WebAuthnSession {
         id: Uuid::parse_str(MOCK_SESSION_UUID).unwrap(),
         user_id: Uuid::parse_str("12345678-1234-1234-1234-123456789abc").unwrap(),
-        data: mock_session_data(),
+        data: mock_register_session_data(),
         purpose: "registration".to_string(),
+        created_at: Utc::now(),
+        expires_at: Utc::now() + chrono::Duration::minutes(10),
+    }
+}
+
+pub fn mock_login_session() -> WebAuthnSession {
+    WebAuthnSession {
+        id: Uuid::parse_str(MOCK_SESSION_UUID).unwrap(),
+        user_id: Uuid::parse_str("12345678-1234-1234-1234-123456789abc").unwrap(),
+        data: mock_login_session_data(),
+        purpose: "login".to_string(),
         created_at: Utc::now(),
         expires_at: Utc::now() + chrono::Duration::minutes(10),
     }
@@ -55,7 +66,7 @@ pub fn mock_refresh_claims() -> TokenClaims {
     }
 }
 
-pub fn mock_credentials() -> serde_json::Value {
+pub fn mock_register_credentials() -> serde_json::Value {
     serde_json::json!({
         "id": "ddqKTpT0rDW9bZGpVsNlC9gRYwA",
         "rawId": "ddqKTpT0rDW9bZGpVsNlC9gRYwA",
@@ -67,7 +78,21 @@ pub fn mock_credentials() -> serde_json::Value {
     })
 }
 
-fn mock_session_data() -> serde_json::Value {
+pub fn mock_login_credentials() -> serde_json::Value {
+    serde_json::json!({
+        "id": "q5JZYrZEHrh-mqND0dYs0zPSyxM",
+        "rawId": "q5JZYrZEHrh-mqND0dYs0zPSyxM",
+        "response": {
+            "authenticatorData": "SZYN5YgOjGh0NBcPZHZgW4_krrmihjLHmVzzuoMdl2MdAAAAAA",
+            "clientDataJSON": "eyJ0eXBlIjoid2ViYXV0aG4uZ2V0IiwiY2hhbGxlbmdlIjoiOUtxZXZOVjhUQU92VWNLM3FQZXBIbHJOOUE1ekt1bWtQLTJrOG5DQW1WYyIsIm9yaWdpbiI6Imh0dHA6Ly9sb2NhbGhvc3Q6MzAwMCIsImNyb3NzT3JpZ2luIjpmYWxzZX0",
+            "signature": "MEYCIQCixkIegU5fsn1PCP3ukNs_v_C-DRjRDzIcPkZ-CNN0KAIhAPKueNP0-pICYi5PBEUozZMbo2HgOA7prF9srY3L15Hz",
+            "userHandle": "IacOeI9BRyGjyUj8B6-58Q"
+        },
+        "type": "public-key"
+    })
+}
+
+fn mock_register_session_data() -> serde_json::Value {
     serde_json::json!({
         "rs": {
             "allow_synchronised_authenticators": true,
@@ -83,6 +108,49 @@ fn mock_session_data() -> serde_json::Value {
             },
             "policy": "required",
             "require_resident_key": false
+        }
+    })
+}
+
+fn mock_login_session_data() -> serde_json::Value {
+    serde_json::json!({
+        "ast": {
+            "allow_backup_eligible_upgrade": true,
+            "appid": null,
+            "challenge": "9KqevNV8TAOvUcK3qPepHlrN9A5zKumkP-2k8nCAmVc",
+            "credentials": [
+                {
+                    "attestation": {
+                        "data": "None",
+                        "metadata": "None"
+                    },
+                    "attestation_format": "none",
+                    "backup_eligible": true,
+                    "backup_state": true,
+                    "counter": 0,
+                    "cred": {
+                        "key": {
+                            "EC_EC2": {
+                                "curve": "SECP256R1",
+                                "x": "zVpmd8-E42cDhFe5jFlykaIHhJKXBpZVOyFPww0hD4s",
+                                "y": "pMqbaDbk8mp6FeTDE2-LR8weuC_E2sr7FX3P5EtfUKA"
+                            }
+                        },
+                        "type_": "ES256"
+                    },
+                    "cred_id": "q5JZYrZEHrh-mqND0dYs0zPSyxM",
+                    "extensions": {
+                        "appid": "NotRequested",
+                        "cred_props": "Ignored",
+                        "cred_protect": "Ignored",
+                        "hmac_create_secret": "NotRequested"
+                    },
+                    "registration_policy": "required",
+                    "transports": null,
+                    "user_verified": true
+                }
+            ],
+            "policy": "required"
         }
     })
 }

--- a/tests/common/helper.rs
+++ b/tests/common/helper.rs
@@ -132,11 +132,6 @@ pub fn get_begin_register_error_test_cases() -> Vec<ErrorTestCase> {
             expected_error: ExpectedError::BadRequest(messages::INVALID_USERNAME_FORMAT),
             test_name: "invalid_username",
         },
-        ErrorTestCase {
-            username: triggers::SERVICE_DOWN,
-            expected_error: ExpectedError::ServiceUnavailable(messages::DB_SERVICE_DOWN),
-            test_name: "service_unavailable",
-        },
     ]
 }
 
@@ -151,6 +146,26 @@ pub fn get_finish_register_error_test_cases() -> Vec<ErrorTestCase> {
             username: triggers::USER_NOT_FOUND,
             expected_error: ExpectedError::NotFound(messages::USER_NOT_FOUND),
             test_name: "user_not_found",
+        },
+        ErrorTestCase {
+            username: triggers::DB_ERROR,
+            expected_error: ExpectedError::InternalServer(messages::DB_CONNECTION_FAILED),
+            test_name: "database_error",
+        },
+    ]
+}
+
+pub fn get_begin_login_error_test_cases() -> Vec<ErrorTestCase> {
+    vec![
+        ErrorTestCase {
+            username: triggers::USER_NOT_FOUND,
+            expected_error: ExpectedError::NotFound(messages::USER_NOT_FOUND),
+            test_name: "user_not_found",
+        },
+        ErrorTestCase {
+            username: triggers::NO_CREDENTIALS,
+            expected_error: ExpectedError::NotFound(messages::NO_CREDENTIALS_FOUND),
+            test_name: "no_credentials",
         },
         ErrorTestCase {
             username: triggers::DB_ERROR,
@@ -192,6 +207,22 @@ pub async fn run_finish_register_error_test_case(test_case: &ErrorTestCase) {
     test_case.expected_error.assert_matches(error);
 }
 
+pub async fn run_begin_login_error_test_case(test_case: &ErrorTestCase) {
+    let auth_service = create_auth_service();
+    let request = create_begin_request_with_username(test_case.username);
+
+    let result = auth_service.begin_login(request).await;
+
+    assert!(
+        result.is_err(),
+        "Test '{}' should fail but succeeded",
+        test_case.test_name
+    );
+
+    let error = result.unwrap_err();
+    test_case.expected_error.assert_matches(error);
+}
+
 pub fn assert_successful_begin_register_response(
     result: Result<rs_passkey_auth::auth::dto::response::BeginResponse, AppError>,
 ) {
@@ -213,4 +244,16 @@ pub fn assert_successful_finish_register_response(
         response.message,
         "Registration completed successfully!".to_string()
     );
+}
+
+pub fn assert_successful_begin_login_response(
+    result: Result<rs_passkey_auth::auth::dto::response::BeginResponse, AppError>,
+) {
+    assert!(result.is_ok(), "begin_login should succeed");
+    let response = result.unwrap();
+    assert!(
+        !response.session_id.is_empty(),
+        "Session ID should not be empty"
+    );
+    assert!(!response.options.is_null(), "Options should not be null");
 }

--- a/tests/common/helper.rs
+++ b/tests/common/helper.rs
@@ -1,0 +1,51 @@
+use chrono::Utc;
+use rs_passkey_auth::{
+    auth::model::{User, WebAuthnSession},
+    utils::jwt::TokenClaims,
+};
+use uuid::Uuid;
+
+pub fn mock_user() -> User {
+    User {
+        id: Uuid::parse_str("12345678-1234-1234-1234-123456789abc").unwrap(),
+        username: "test_user".to_string(),
+        role: Some("user".to_string()),
+        status: "active".to_string(),
+        created_at: Utc::now(),
+        updated_at: Utc::now(),
+        is_active: true,
+    }
+}
+
+pub fn mock_session() -> WebAuthnSession {
+    WebAuthnSession {
+        id: Uuid::parse_str("12345678-1234-1234-1234-123456789def").unwrap(),
+        user_id: Uuid::parse_str("12345678-1234-1234-1234-123456789abc").unwrap(),
+        data: serde_json::json!({}),
+        purpose: "registration".to_string(),
+        created_at: Utc::now(),
+        expires_at: Utc::now() + chrono::Duration::minutes(10),
+    }
+}
+
+pub fn mock_access_claims() -> TokenClaims {
+    TokenClaims {
+        sub: Uuid::parse_str("12345678-1234-1234-1234-123456789ghi").unwrap(),
+        username: "test_user".to_string(),
+        role: Some("user".to_string()),
+        exp: chrono::Utc::now().timestamp() + 900,
+        iat: chrono::Utc::now().timestamp(),
+        jti: None,
+    }
+}
+
+pub fn mock_refresh_claims() -> TokenClaims {
+    TokenClaims {
+        sub: Uuid::parse_str("12345678-1234-1234-1234-123456789llm").unwrap(),
+        username: "test_user".to_string(),
+        role: Some("user".to_string()),
+        exp: chrono::Utc::now().timestamp() + 3600,
+        iat: chrono::Utc::now().timestamp(),
+        jti: Some("mock_jti".to_string()),
+    }
+}

--- a/tests/common/helper.rs
+++ b/tests/common/helper.rs
@@ -140,11 +140,47 @@ pub fn get_begin_register_error_test_cases() -> Vec<ErrorTestCase> {
     ]
 }
 
-pub async fn run_error_test_case(test_case: &ErrorTestCase) {
+pub fn get_finish_register_error_test_cases() -> Vec<ErrorTestCase> {
+    vec![
+        ErrorTestCase {
+            username: triggers::SESSION_NOT_FOUND,
+            expected_error: ExpectedError::NotFound(messages::SESSION_NOT_FOUND),
+            test_name: "session_not_found",
+        },
+        ErrorTestCase {
+            username: triggers::USER_NOT_FOUND,
+            expected_error: ExpectedError::NotFound(messages::USER_NOT_FOUND),
+            test_name: "user_not_found",
+        },
+        ErrorTestCase {
+            username: triggers::DB_ERROR,
+            expected_error: ExpectedError::InternalServer(messages::DB_CONNECTION_FAILED),
+            test_name: "database_error",
+        },
+    ]
+}
+
+pub async fn run_begin_register_error_test_case(test_case: &ErrorTestCase) {
     let auth_service = create_auth_service();
     let request = create_begin_request_with_username(test_case.username);
 
     let result = auth_service.begin_register(request).await;
+
+    assert!(
+        result.is_err(),
+        "Test '{}' should fail but succeeded",
+        test_case.test_name
+    );
+
+    let error = result.unwrap_err();
+    test_case.expected_error.assert_matches(error);
+}
+
+pub async fn run_finish_register_error_test_case(test_case: &ErrorTestCase) {
+    let auth_service = create_auth_service();
+    let request = create_finish_request_with_username(test_case.username);
+
+    let result = auth_service.finish_register(request).await;
 
     assert!(
         result.is_err(),

--- a/tests/common/helper.rs
+++ b/tests/common/helper.rs
@@ -1,51 +1,149 @@
-use chrono::Utc;
 use rs_passkey_auth::{
-    auth::model::{User, WebAuthnSession},
-    utils::jwt::TokenClaims,
+    app::AppError,
+    auth::{dto::request::BeginRequest, service::AuthService},
 };
-use uuid::Uuid;
+use std::sync::Arc;
+use url::Url;
+use webauthn_rs::WebauthnBuilder;
 
-pub fn mock_user() -> User {
-    User {
-        id: Uuid::parse_str("12345678-1234-1234-1234-123456789abc").unwrap(),
-        username: "test_user".to_string(),
-        role: Some("user".to_string()),
-        status: "active".to_string(),
-        created_at: Utc::now(),
-        updated_at: Utc::now(),
-        is_active: true,
+use crate::common::{
+    constants::{messages, test_data, triggers},
+    mock::{MockAuthRepository, MockJwtService},
+};
+
+pub fn create_auth_service() -> AuthService<MockAuthRepository, MockJwtService> {
+    let mock_auth_repo = Arc::new(MockAuthRepository);
+    let mock_jwt_service = Arc::new(MockJwtService);
+
+    let rp_origin = Url::parse(test_data::WEBAUTHN_ORIGIN).unwrap();
+    let builder = WebauthnBuilder::new(test_data::WEBAUTHN_RP_NAME, &rp_origin).unwrap();
+    let webauthn = builder.build().unwrap();
+
+    AuthService::new(webauthn, mock_auth_repo, mock_jwt_service)
+}
+
+pub fn create_begin_request() -> BeginRequest {
+    BeginRequest {
+        username: test_data::DEFAULT_USERNAME.to_string(),
+        role: Some(test_data::DEFAULT_ROLE.to_string()),
     }
 }
 
-pub fn mock_session() -> WebAuthnSession {
-    WebAuthnSession {
-        id: Uuid::parse_str("12345678-1234-1234-1234-123456789def").unwrap(),
-        user_id: Uuid::parse_str("12345678-1234-1234-1234-123456789abc").unwrap(),
-        data: serde_json::json!({}),
-        purpose: "registration".to_string(),
-        created_at: Utc::now(),
-        expires_at: Utc::now() + chrono::Duration::minutes(10),
+pub fn create_begin_request_with_username(username: &str) -> BeginRequest {
+    BeginRequest {
+        username: username.to_string(),
+        role: Some(test_data::DEFAULT_ROLE.to_string()),
     }
 }
 
-pub fn mock_access_claims() -> TokenClaims {
-    TokenClaims {
-        sub: Uuid::parse_str("12345678-1234-1234-1234-123456789ghi").unwrap(),
-        username: "test_user".to_string(),
-        role: Some("user".to_string()),
-        exp: chrono::Utc::now().timestamp() + 900,
-        iat: chrono::Utc::now().timestamp(),
-        jti: None,
+pub struct ErrorTestCase {
+    pub username: &'static str,
+    pub expected_error: ExpectedError,
+    pub test_name: &'static str,
+}
+
+pub enum ExpectedError {
+    AlreadyExists(&'static str),
+    InternalServer(&'static str),
+    BadRequest(&'static str),
+    ServiceUnavailable(&'static str),
+    NotFound(&'static str),
+    Unauthorized(&'static str),
+}
+
+impl ExpectedError {
+    pub fn assert_matches(&self, error: AppError) {
+        match (self, error) {
+            (ExpectedError::AlreadyExists(expected_msg), AppError::AlreadyExists(actual_msg)) => {
+                assert_eq!(*expected_msg, actual_msg);
+            }
+            (ExpectedError::InternalServer(expected_msg), AppError::InternalServer(actual_msg)) => {
+                assert_eq!(*expected_msg, actual_msg);
+            }
+            (ExpectedError::BadRequest(expected_msg), AppError::BadRequest(actual_msg)) => {
+                assert_eq!(*expected_msg, actual_msg);
+            }
+            (
+                ExpectedError::ServiceUnavailable(expected_msg),
+                AppError::ServiceUnavailable(actual_msg),
+            ) => {
+                assert_eq!(*expected_msg, actual_msg);
+            }
+            (ExpectedError::NotFound(expected_msg), AppError::NotFound(actual_msg)) => {
+                assert_eq!(*expected_msg, actual_msg);
+            }
+            (ExpectedError::Unauthorized(expected_msg), AppError::Unauthorized(actual_msg)) => {
+                assert_eq!(*expected_msg, actual_msg);
+            }
+            (expected, actual) => {
+                panic!("Expected {:?} but got {:?}", expected, actual);
+            }
+        }
     }
 }
 
-pub fn mock_refresh_claims() -> TokenClaims {
-    TokenClaims {
-        sub: Uuid::parse_str("12345678-1234-1234-1234-123456789llm").unwrap(),
-        username: "test_user".to_string(),
-        role: Some("user".to_string()),
-        exp: chrono::Utc::now().timestamp() + 3600,
-        iat: chrono::Utc::now().timestamp(),
-        jti: Some("mock_jti".to_string()),
+impl std::fmt::Debug for ExpectedError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ExpectedError::AlreadyExists(msg) => write!(f, "AlreadyExists({})", msg),
+            ExpectedError::InternalServer(msg) => write!(f, "InternalServer({})", msg),
+            ExpectedError::BadRequest(msg) => write!(f, "BadRequest({})", msg),
+            ExpectedError::ServiceUnavailable(msg) => write!(f, "ServiceUnavailable({})", msg),
+            ExpectedError::NotFound(msg) => write!(f, "NotFound({})", msg),
+            ExpectedError::Unauthorized(msg) => write!(f, "Unauthorized({})", msg),
+        }
     }
+}
+
+pub fn get_begin_register_error_test_cases() -> Vec<ErrorTestCase> {
+    vec![
+        ErrorTestCase {
+            username: triggers::USER_ALREADY_EXISTS,
+            expected_error: ExpectedError::AlreadyExists(messages::USER_ALREADY_EXISTS),
+            test_name: "user_already_exists",
+        },
+        ErrorTestCase {
+            username: triggers::DB_ERROR,
+            expected_error: ExpectedError::InternalServer(messages::DB_CONNECTION_FAILED),
+            test_name: "database_error",
+        },
+        ErrorTestCase {
+            username: triggers::INVALID_USERNAME,
+            expected_error: ExpectedError::BadRequest(messages::INVALID_USERNAME_FORMAT),
+            test_name: "invalid_username",
+        },
+        ErrorTestCase {
+            username: triggers::SERVICE_DOWN,
+            expected_error: ExpectedError::ServiceUnavailable(messages::DB_SERVICE_DOWN),
+            test_name: "service_unavailable",
+        },
+    ]
+}
+
+pub async fn run_error_test_case(test_case: &ErrorTestCase) {
+    let auth_service = create_auth_service();
+    let request = create_begin_request_with_username(test_case.username);
+
+    let result = auth_service.begin_register(request).await;
+
+    assert!(
+        result.is_err(),
+        "Test '{}' should fail but succeeded",
+        test_case.test_name
+    );
+
+    let error = result.unwrap_err();
+    test_case.expected_error.assert_matches(error);
+}
+
+pub fn assert_successful_begin_register_response(
+    result: Result<rs_passkey_auth::auth::dto::response::BeginResponse, AppError>,
+) {
+    assert!(result.is_ok(), "begin_register should succeed");
+    let response = result.unwrap();
+    assert!(
+        !response.session_id.is_empty(),
+        "Session ID should not be empty"
+    );
+    assert!(!response.options.is_null(), "Options should not be null");
 }

--- a/tests/common/helper.rs
+++ b/tests/common/helper.rs
@@ -1,13 +1,17 @@
 use rs_passkey_auth::{
     app::AppError,
-    auth::{dto::request::BeginRequest, service::AuthService},
+    auth::{
+        dto::request::{BeginRequest, FinishRequest},
+        service::AuthService,
+    },
 };
 use std::sync::Arc;
 use url::Url;
 use webauthn_rs::WebauthnBuilder;
 
 use crate::common::{
-    constants::{messages, test_data, triggers},
+    constants::{messages, responses::MOCK_SESSION_UUID, test_data, triggers},
+    fixture::mock_credentials,
     mock::{MockAuthRepository, MockJwtService},
 };
 
@@ -29,10 +33,26 @@ pub fn create_begin_request() -> BeginRequest {
     }
 }
 
+pub fn create_finish_request() -> FinishRequest {
+    FinishRequest {
+        username: test_data::DEFAULT_USERNAME.to_string(),
+        session_id: MOCK_SESSION_UUID.to_string(),
+        credentials: mock_credentials(),
+    }
+}
+
 pub fn create_begin_request_with_username(username: &str) -> BeginRequest {
     BeginRequest {
         username: username.to_string(),
         role: Some(test_data::DEFAULT_ROLE.to_string()),
+    }
+}
+
+pub fn create_finish_request_with_username(username: &str) -> FinishRequest {
+    FinishRequest {
+        username: username.to_string(),
+        session_id: MOCK_SESSION_UUID.to_string(),
+        credentials: mock_credentials(),
     }
 }
 
@@ -146,4 +166,15 @@ pub fn assert_successful_begin_register_response(
         "Session ID should not be empty"
     );
     assert!(!response.options.is_null(), "Options should not be null");
+}
+
+pub fn assert_successful_finish_register_response(
+    result: Result<rs_passkey_auth::auth::dto::response::MessageResponse, AppError>,
+) {
+    assert!(result.is_ok(), "finish_register should succeed");
+    let response = result.unwrap();
+    assert_eq!(
+        response.message,
+        "Registration completed successfully!".to_string()
+    );
 }

--- a/tests/common/helper.rs
+++ b/tests/common/helper.rs
@@ -11,7 +11,7 @@ use webauthn_rs::WebauthnBuilder;
 
 use crate::common::{
     constants::{messages, responses::MOCK_SESSION_UUID, test_data, triggers},
-    fixture::mock_credentials,
+    fixture::{mock_login_credentials, mock_register_credentials},
     mock::{MockAuthRepository, MockJwtService},
 };
 
@@ -33,11 +33,19 @@ pub fn create_begin_request() -> BeginRequest {
     }
 }
 
-pub fn create_finish_request() -> FinishRequest {
+pub fn create_register_finish_request() -> FinishRequest {
     FinishRequest {
         username: test_data::DEFAULT_USERNAME.to_string(),
         session_id: MOCK_SESSION_UUID.to_string(),
-        credentials: mock_credentials(),
+        credentials: mock_register_credentials(),
+    }
+}
+
+pub fn create_login_finish_request() -> FinishRequest {
+    FinishRequest {
+        username: test_data::DEFAULT_USERNAME.to_string(),
+        session_id: MOCK_SESSION_UUID.to_string(),
+        credentials: mock_login_credentials(),
     }
 }
 
@@ -48,11 +56,19 @@ pub fn create_begin_request_with_username(username: &str) -> BeginRequest {
     }
 }
 
-pub fn create_finish_request_with_username(username: &str) -> FinishRequest {
+pub fn create_register_finish_request_with_username(username: &str) -> FinishRequest {
     FinishRequest {
         username: username.to_string(),
         session_id: MOCK_SESSION_UUID.to_string(),
-        credentials: mock_credentials(),
+        credentials: mock_register_credentials(),
+    }
+}
+
+pub fn create_login_finish_request_with_username(username: &str) -> FinishRequest {
+    FinishRequest {
+        username: username.to_string(),
+        session_id: MOCK_SESSION_UUID.to_string(),
+        credentials: mock_login_credentials(),
     }
 }
 
@@ -193,7 +209,7 @@ pub async fn run_begin_register_error_test_case(test_case: &ErrorTestCase) {
 
 pub async fn run_finish_register_error_test_case(test_case: &ErrorTestCase) {
     let auth_service = create_auth_service();
-    let request = create_finish_request_with_username(test_case.username);
+    let request = create_register_finish_request_with_username(test_case.username);
 
     let result = auth_service.finish_register(request).await;
 
@@ -256,4 +272,17 @@ pub fn assert_successful_begin_login_response(
         "Session ID should not be empty"
     );
     assert!(!response.options.is_null(), "Options should not be null");
+}
+
+pub fn assert_successful_finish_login_response(
+    result: Result<(rs_passkey_auth::auth::dto::response::TokenResponse, String), AppError>,
+) {
+    assert!(result.is_ok(), "finish_login should succeed");
+    let (token_response, refresh) = result.unwrap();
+    assert_eq!(
+        token_response.message,
+        "Login completed successfully!".to_string()
+    );
+    assert_eq!(token_response.access_token, "mock_access_token".to_string());
+    assert_eq!(refresh, "mock_refresh_token".to_string());
 }

--- a/tests/common/helper.rs
+++ b/tests/common/helper.rs
@@ -191,6 +191,26 @@ pub fn get_begin_login_error_test_cases() -> Vec<ErrorTestCase> {
     ]
 }
 
+pub fn get_finish_login_error_test_cases() -> Vec<ErrorTestCase> {
+    vec![
+        ErrorTestCase {
+            username: triggers::USER_NOT_FOUND,
+            expected_error: ExpectedError::NotFound(messages::USER_NOT_FOUND),
+            test_name: "user_not_found",
+        },
+        ErrorTestCase {
+            username: triggers::SESSION_NOT_FOUND,
+            expected_error: ExpectedError::NotFound(messages::SESSION_NOT_FOUND),
+            test_name: "session_not_found",
+        },
+        ErrorTestCase {
+            username: triggers::DB_ERROR,
+            expected_error: ExpectedError::InternalServer(messages::DB_CONNECTION_FAILED),
+            test_name: "database_error",
+        },
+    ]
+}
+
 pub async fn run_begin_register_error_test_case(test_case: &ErrorTestCase) {
     let auth_service = create_auth_service();
     let request = create_begin_request_with_username(test_case.username);
@@ -228,6 +248,22 @@ pub async fn run_begin_login_error_test_case(test_case: &ErrorTestCase) {
     let request = create_begin_request_with_username(test_case.username);
 
     let result = auth_service.begin_login(request).await;
+
+    assert!(
+        result.is_err(),
+        "Test '{}' should fail but succeeded",
+        test_case.test_name
+    );
+
+    let error = result.unwrap_err();
+    test_case.expected_error.assert_matches(error);
+}
+
+pub async fn run_finish_login_error_test_case(test_case: &ErrorTestCase) {
+    let auth_service = create_auth_service();
+    let request = create_login_finish_request_with_username(test_case.username);
+
+    let result = auth_service.finish_login(request).await;
 
     assert!(
         result.is_err(),

--- a/tests/common/mock.rs
+++ b/tests/common/mock.rs
@@ -14,14 +14,36 @@ use crate::common::{
     fixture::{self, mock_access_claims, mock_refresh_claims, mock_user},
 };
 
-pub struct MockAuthRepository;
+pub struct MockAuthRepository {
+    is_healthy: bool,
+}
+
+impl Default for MockAuthRepository {
+    fn default() -> Self {
+        Self { is_healthy: true }
+    }
+}
+
+impl MockAuthRepository {
+    pub fn unhealthy() -> Self {
+        Self { is_healthy: false }
+    }
+}
 
 impl AuthRepository for MockAuthRepository {
     async fn check_db(&self) -> ServiceHealth {
-        ServiceHealth {
-            status: HealthStatus::Healthy,
-            message: responses::HEALTHY_STATUS_OK.to_string(),
-            response_time_ms: Some(responses::DB_RESPONSE_TIME_MS),
+        if self.is_healthy {
+            ServiceHealth {
+                status: HealthStatus::Healthy,
+                message: responses::HEALTHY_STATUS_OK.to_string(),
+                response_time_ms: Some(responses::DB_RESPONSE_TIME_MS),
+            }
+        } else {
+            ServiceHealth {
+                status: HealthStatus::Unhealthy,
+                message: "Database connection failed".to_string(),
+                response_time_ms: None,
+            }
         }
     }
 
@@ -147,7 +169,21 @@ impl AuthRepository for MockAuthRepository {
     }
 }
 
-pub struct MockJwtService;
+pub struct MockJwtService {
+    is_healthy: bool,
+}
+
+impl Default for MockJwtService {
+    fn default() -> Self {
+        Self { is_healthy: true }
+    }
+}
+
+impl MockJwtService {
+    pub fn unhealthy() -> Self {
+        Self { is_healthy: false }
+    }
+}
 
 impl JwtService for MockJwtService {
     fn get_public_key_base64(&self) -> String {
@@ -155,10 +191,18 @@ impl JwtService for MockJwtService {
     }
 
     async fn check_redis(&self) -> ServiceHealth {
-        ServiceHealth {
-            status: HealthStatus::Healthy,
-            message: responses::HEALTHY_STATUS_OK.to_string(),
-            response_time_ms: Some(responses::REDIS_RESPONSE_TIME_MS),
+        if self.is_healthy {
+            ServiceHealth {
+                status: HealthStatus::Healthy,
+                message: responses::HEALTHY_STATUS_OK.to_string(),
+                response_time_ms: Some(responses::REDIS_RESPONSE_TIME_MS),
+            }
+        } else {
+            ServiceHealth {
+                status: HealthStatus::Unhealthy,
+                message: "Redis connection failed".to_string(),
+                response_time_ms: None,
+            }
         }
     }
 

--- a/tests/common/mock.rs
+++ b/tests/common/mock.rs
@@ -138,16 +138,10 @@ impl AuthRepository for MockAuthRepository {
     async fn complete_registration(
         &self,
         _user_id: Uuid,
-        username: &str,
+        _username: &str,
         _passkey: &webauthn_rs::prelude::Passkey,
     ) -> Result<(), AppError> {
-        match username {
-            triggers::REGISTRATION_FAILED => Err(AppError::InternalServer(
-                messages::REGISTRATION_FAILED.to_string(),
-            )),
-            triggers::DB_ERROR => Err(AppError::InternalServer(messages::DB_ERROR.to_string())),
-            _ => Ok(()),
-        }
+        Ok(())
     }
 }
 

--- a/tests/common/mock.rs
+++ b/tests/common/mock.rs
@@ -9,7 +9,10 @@ use rs_passkey_auth::{
 };
 use uuid::Uuid;
 
-use crate::common::helper::{mock_access_claims, mock_refresh_claims, mock_session, mock_user};
+use crate::common::{
+    constants::{messages, responses, triggers},
+    fixture::{mock_access_claims, mock_refresh_claims, mock_session, mock_user},
+};
 
 pub struct MockAuthRepository;
 
@@ -17,60 +20,134 @@ impl AuthRepository for MockAuthRepository {
     async fn check_db(&self) -> ServiceHealth {
         ServiceHealth {
             status: HealthStatus::Healthy,
-            message: "OK".to_string(),
-            response_time_ms: Some(100),
+            message: responses::HEALTHY_STATUS_OK.to_string(),
+            response_time_ms: Some(responses::DB_RESPONSE_TIME_MS),
         }
     }
 
-    async fn create_user(&self, _username: &str, _role: Option<&str>) -> Result<User, AppError> {
-        Ok(mock_user())
+    async fn create_user(&self, username: &str, _role: Option<&str>) -> Result<User, AppError> {
+        match username {
+            triggers::USER_ALREADY_EXISTS => Err(AppError::AlreadyExists(
+                messages::USER_ALREADY_EXISTS.to_string(),
+            )),
+            triggers::DB_ERROR => Err(AppError::InternalServer(
+                messages::DB_CONNECTION_FAILED.to_string(),
+            )),
+            triggers::INVALID_USERNAME => Err(AppError::BadRequest(
+                messages::INVALID_USERNAME_FORMAT.to_string(),
+            )),
+            triggers::SERVICE_DOWN => Err(AppError::ServiceUnavailable(
+                messages::DB_SERVICE_DOWN.to_string(),
+            )),
+            _ => Ok(mock_user()),
+        }
     }
 
-    async fn get_user_by_username(&self, _username: &str) -> Result<User, AppError> {
-        Ok(mock_user())
+    async fn get_user_by_username(&self, username: &str) -> Result<User, AppError> {
+        match username {
+            triggers::USER_NOT_FOUND => {
+                Err(AppError::NotFound(messages::USER_NOT_FOUND.to_string()))
+            }
+            triggers::DB_ERROR => Err(AppError::InternalServer(
+                messages::DB_CONNECTION_FAILED.to_string(),
+            )),
+            triggers::SERVICE_DOWN => Err(AppError::ServiceUnavailable(
+                messages::DB_SERVICE_DOWN.to_string(),
+            )),
+            _ => Ok(mock_user()),
+        }
     }
 
     async fn get_user_and_session(
         &self,
         _session_id: Uuid,
-        _username: &str,
+        username: &str,
         _purpose: &str,
     ) -> Result<(User, WebAuthnSession), AppError> {
-        Ok((mock_user(), mock_session()))
+        match username {
+            triggers::SESSION_NOT_FOUND => {
+                Err(AppError::NotFound(messages::SESSION_NOT_FOUND.to_string()))
+            }
+            triggers::USER_NOT_FOUND => {
+                Err(AppError::NotFound(messages::USER_NOT_FOUND.to_string()))
+            }
+            triggers::DB_ERROR => Err(AppError::InternalServer(
+                messages::DB_CONNECTION_FAILED.to_string(),
+            )),
+            _ => Ok((mock_user(), mock_session())),
+        }
     }
 
     async fn get_active_user_with_credential(
         &self,
-        _username: &str,
+        username: &str,
     ) -> Result<(User, Vec<webauthn_rs::prelude::Passkey>), AppError> {
-        Ok((mock_user(), vec![]))
+        match username {
+            triggers::USER_NOT_FOUND => {
+                Err(AppError::NotFound(messages::USER_NOT_FOUND.to_string()))
+            }
+            triggers::NO_CREDENTIALS => Err(AppError::NotFound(
+                messages::NO_CREDENTIALS_FOUND.to_string(),
+            )),
+            triggers::DB_ERROR => Err(AppError::InternalServer(
+                messages::DB_CONNECTION_FAILED.to_string(),
+            )),
+            _ => Ok((mock_user(), vec![])),
+        }
     }
 
     async fn create_webauthn_session(
         &self,
-        _user_id: Uuid,
+        user_id: Uuid,
         _data: serde_json::Value,
         _purpose: &str,
     ) -> Result<Uuid, AppError> {
-        let id = Uuid::parse_str("12345678-1234-1234-1234-123456789def").unwrap();
+        if user_id.to_string() == triggers::SESSION_CREATION_ERROR_UUID {
+            return Err(AppError::InternalServer(
+                messages::SESSION_CREATION_FAILED.to_string(),
+            ));
+        }
+        if user_id.to_string() == triggers::SERVICE_UNAVAILABLE_UUID {
+            return Err(AppError::ServiceUnavailable(
+                messages::DB_SERVICE_DOWN.to_string(),
+            ));
+        }
+        let id = Uuid::parse_str(responses::MOCK_SESSION_UUID).unwrap();
         Ok(id)
     }
 
-    async fn delete_webauthn_session(&self, _id: Uuid) -> Result<(), AppError> {
+    async fn delete_webauthn_session(&self, id: Uuid) -> Result<(), AppError> {
+        if id.to_string() == triggers::SESSION_NOT_FOUND_UUID {
+            return Err(AppError::NotFound(messages::SESSION_NOT_FOUND.to_string()));
+        }
         Ok(())
     }
 
-    async fn update_credential(&self, _cred_id: &[u8], _new_counter: u32) -> Result<(), AppError> {
+    async fn update_credential(&self, cred_id: &[u8], _new_counter: u32) -> Result<(), AppError> {
+        if cred_id == triggers::ERROR_CRED_ID {
+            return Err(AppError::NotFound(
+                messages::CREDENTIAL_NOT_FOUND.to_string(),
+            ));
+        }
+        if cred_id == triggers::DB_ERROR_CRED_ID {
+            return Err(AppError::InternalServer(messages::DB_ERROR.to_string()));
+        }
         Ok(())
     }
 
     async fn complete_registration(
         &self,
         _user_id: Uuid,
-        _username: &str,
+        username: &str,
         _passkey: &webauthn_rs::prelude::Passkey,
     ) -> Result<(), AppError> {
-        Ok(())
+        match username {
+            triggers::REGISTRATION_FAILED => Err(AppError::InternalServer(
+                messages::REGISTRATION_FAILED.to_string(),
+            )),
+            triggers::DB_ERROR => Err(AppError::InternalServer(messages::DB_ERROR.to_string())),
+            _ => Ok(()),
+        }
     }
 }
 
@@ -78,14 +155,14 @@ pub struct MockJwtService;
 
 impl JwtService for MockJwtService {
     fn get_public_key_base64(&self) -> String {
-        "mock_public_key".to_string()
+        responses::MOCK_PUBLIC_KEY.to_string()
     }
 
     async fn check_redis(&self) -> ServiceHealth {
         ServiceHealth {
             status: HealthStatus::Healthy,
-            message: "OK".to_string(),
-            response_time_ms: Some(30),
+            message: responses::HEALTHY_STATUS_OK.to_string(),
+            response_time_ms: Some(responses::REDIS_RESPONSE_TIME_MS),
         }
     }
 
@@ -96,24 +173,69 @@ impl JwtService for MockJwtService {
         _role: Option<&str>,
     ) -> TokenPair {
         TokenPair {
-            access_token: "mock_access_token".to_string(),
-            refresh_token: "mock_refresh_token".to_string(),
+            access_token: responses::MOCK_ACCESS_TOKEN.to_string(),
+            refresh_token: responses::MOCK_REFRESH_TOKEN.to_string(),
         }
     }
 
-    async fn validate_refresh(&self, _token: &str) -> Result<TokenClaims, AppError> {
-        Ok(mock_refresh_claims())
+    async fn validate_refresh(&self, token: &str) -> Result<TokenClaims, AppError> {
+        match token {
+            triggers::INVALID_TOKEN => Err(AppError::Unauthorized(
+                messages::INVALID_REFRESH_TOKEN.to_string(),
+            )),
+            triggers::EXPIRED_TOKEN => {
+                Err(AppError::Unauthorized(messages::TOKEN_EXPIRED.to_string()))
+            }
+            triggers::MALFORMED_TOKEN => {
+                Err(AppError::BadRequest(messages::MALFORMED_TOKEN.to_string()))
+            }
+            triggers::REDIS_ERROR => Err(AppError::InternalServer(
+                messages::REDIS_CONNECTION_FAILED.to_string(),
+            )),
+            _ => Ok(mock_refresh_claims()),
+        }
     }
 
-    async fn validate_access(&self, _token: &str) -> Result<TokenClaims, AppError> {
-        Ok(mock_access_claims())
+    async fn validate_access(&self, token: &str) -> Result<TokenClaims, AppError> {
+        match token {
+            triggers::INVALID_TOKEN => Err(AppError::Unauthorized(
+                messages::INVALID_ACCESS_TOKEN.to_string(),
+            )),
+            triggers::EXPIRED_TOKEN => {
+                Err(AppError::Unauthorized(messages::TOKEN_EXPIRED.to_string()))
+            }
+            triggers::BLACKLISTED_TOKEN => Err(AppError::Unauthorized(
+                messages::TOKEN_BLACKLISTED.to_string(),
+            )),
+            triggers::MALFORMED_TOKEN => {
+                Err(AppError::BadRequest(messages::MALFORMED_TOKEN.to_string()))
+            }
+            triggers::REDIS_ERROR => Err(AppError::InternalServer(
+                messages::REDIS_CONNECTION_FAILED.to_string(),
+            )),
+            _ => Ok(mock_access_claims()),
+        }
     }
 
-    async fn blacklist(&self, _jti: &str, _exp: i64) -> Result<(), AppError> {
-        Ok(())
+    async fn blacklist(&self, jti: &str, _exp: i64) -> Result<(), AppError> {
+        match jti {
+            triggers::REDIS_ERROR => Err(AppError::InternalServer(
+                messages::REDIS_CONNECTION_FAILED.to_string(),
+            )),
+            triggers::SERVICE_DOWN => Err(AppError::ServiceUnavailable(
+                messages::REDIS_SERVICE_DOWN.to_string(),
+            )),
+            _ => Ok(()),
+        }
     }
 
-    async fn is_blacklisted(&self, _jti: &str) -> Result<bool, AppError> {
-        Ok(false)
+    async fn is_blacklisted(&self, jti: &str) -> Result<bool, AppError> {
+        match jti {
+            triggers::BLACKLISTED_JTI => Ok(true),
+            triggers::REDIS_ERROR => Err(AppError::InternalServer(
+                messages::REDIS_CONNECTION_FAILED.to_string(),
+            )),
+            _ => Ok(false),
+        }
     }
 }

--- a/tests/common/mock.rs
+++ b/tests/common/mock.rs
@@ -10,7 +10,7 @@ use rs_passkey_auth::{
 use uuid::Uuid;
 
 use crate::common::{
-    constants::{messages, responses, triggers},
+    constants::{messages, responses, test_data, triggers},
     fixture::{self, mock_access_claims, mock_refresh_claims, mock_user},
 };
 
@@ -41,7 +41,7 @@ impl AuthRepository for MockAuthRepository {
         } else {
             ServiceHealth {
                 status: HealthStatus::Unhealthy,
-                message: "Database connection failed".to_string(),
+                message: messages::DB_CONNECTION_FAILED.to_string(),
                 response_time_ms: None,
             }
         }
@@ -102,8 +102,8 @@ impl AuthRepository for MockAuthRepository {
         }
 
         let session = match purpose {
-            "login" => fixture::mock_login_session(),
-            "registration" => fixture::mock_register_session(),
+            test_data::LOGIN_SESSION_PURPOSE => fixture::mock_login_session(),
+            test_data::REGISTRATION_SESSION_PURPOSE => fixture::mock_register_session(),
             _ => fixture::mock_register_session(),
         };
 
@@ -200,7 +200,7 @@ impl JwtService for MockJwtService {
         } else {
             ServiceHealth {
                 status: HealthStatus::Unhealthy,
-                message: "Redis connection failed".to_string(),
+                message: messages::REDIS_CONNECTION_FAILED.to_string(),
                 response_time_ms: None,
             }
         }

--- a/tests/common/mock.rs
+++ b/tests/common/mock.rs
@@ -133,15 +133,7 @@ impl AuthRepository for MockAuthRepository {
         Ok(())
     }
 
-    async fn update_credential(&self, cred_id: &[u8], _new_counter: u32) -> Result<(), AppError> {
-        if cred_id == triggers::ERROR_CRED_ID {
-            return Err(AppError::NotFound(
-                messages::CREDENTIAL_NOT_FOUND.to_string(),
-            ));
-        }
-        if cred_id == triggers::DB_ERROR_CRED_ID {
-            return Err(AppError::InternalServer(messages::DB_ERROR.to_string()));
-        }
+    async fn update_credential(&self, _cred_id: &[u8], _new_counter: u32) -> Result<(), AppError> {
         Ok(())
     }
 

--- a/tests/common/mock.rs
+++ b/tests/common/mock.rs
@@ -1,0 +1,119 @@
+use rs_passkey_auth::{
+    app::AppError,
+    auth::{
+        dto::response::{HealthStatus, ServiceHealth},
+        model::{User, WebAuthnSession},
+        traits::{AuthRepository, JwtService},
+    },
+    utils::jwt::{TokenClaims, TokenPair},
+};
+use uuid::Uuid;
+
+use crate::common::helper::{mock_access_claims, mock_refresh_claims, mock_session, mock_user};
+
+pub struct MockAuthRepository;
+
+impl AuthRepository for MockAuthRepository {
+    async fn check_db(&self) -> ServiceHealth {
+        ServiceHealth {
+            status: HealthStatus::Healthy,
+            message: "OK".to_string(),
+            response_time_ms: Some(100),
+        }
+    }
+
+    async fn create_user(&self, _username: &str, _role: Option<&str>) -> Result<User, AppError> {
+        Ok(mock_user())
+    }
+
+    async fn get_user_by_username(&self, _username: &str) -> Result<User, AppError> {
+        Ok(mock_user())
+    }
+
+    async fn get_user_and_session(
+        &self,
+        _session_id: Uuid,
+        _username: &str,
+        _purpose: &str,
+    ) -> Result<(User, WebAuthnSession), AppError> {
+        Ok((mock_user(), mock_session()))
+    }
+
+    async fn get_active_user_with_credential(
+        &self,
+        _username: &str,
+    ) -> Result<(User, Vec<webauthn_rs::prelude::Passkey>), AppError> {
+        Ok((mock_user(), vec![]))
+    }
+
+    async fn create_webauthn_session(
+        &self,
+        _user_id: Uuid,
+        _data: serde_json::Value,
+        _purpose: &str,
+    ) -> Result<Uuid, AppError> {
+        let id = Uuid::parse_str("12345678-1234-1234-1234-123456789def").unwrap();
+        Ok(id)
+    }
+
+    async fn delete_webauthn_session(&self, _id: Uuid) -> Result<(), AppError> {
+        Ok(())
+    }
+
+    async fn update_credential(&self, _cred_id: &[u8], _new_counter: u32) -> Result<(), AppError> {
+        Ok(())
+    }
+
+    async fn complete_registration(
+        &self,
+        _user_id: Uuid,
+        _username: &str,
+        _passkey: &webauthn_rs::prelude::Passkey,
+    ) -> Result<(), AppError> {
+        Ok(())
+    }
+}
+
+pub struct MockJwtService;
+
+impl JwtService for MockJwtService {
+    fn get_public_key_base64(&self) -> String {
+        "mock_public_key".to_string()
+    }
+
+    async fn check_redis(&self) -> ServiceHealth {
+        ServiceHealth {
+            status: HealthStatus::Healthy,
+            message: "OK".to_string(),
+            response_time_ms: Some(30),
+        }
+    }
+
+    fn generate_token_pair(
+        &self,
+        _user_id: Uuid,
+        _username: &str,
+        _role: Option<&str>,
+    ) -> TokenPair {
+        TokenPair {
+            access_token: "mock_access_token".to_string(),
+            refresh_token: "mock_refresh_token".to_string(),
+        }
+    }
+
+    async fn validate_refresh(&self, _token: &str) -> Result<TokenClaims, AppError> {
+        Ok(mock_refresh_claims())
+    }
+
+    async fn validate_access(&self, _token: &str) -> Result<TokenClaims, AppError> {
+        Ok(mock_access_claims())
+    }
+
+    async fn blacklist(&self, _jti: &str, _exp: i64) -> Result<(), AppError> {
+        Ok(())
+    }
+
+    async fn is_blacklisted(&self, _jti: &str) -> Result<bool, AppError> {
+        Ok(false)
+    }
+}

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,0 +1,2 @@
+pub mod helper;
+pub mod mock;

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,2 +1,4 @@
+pub mod constants;
+pub mod fixture;
 pub mod helper;
 pub mod mock;

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -1,0 +1,2 @@
+pub mod common;
+pub mod unit;

--- a/tests/unit/mod.rs
+++ b/tests/unit/mod.rs
@@ -1,0 +1,1 @@
+pub mod service;

--- a/tests/unit/service.rs
+++ b/tests/unit/service.rs
@@ -2,14 +2,14 @@ use crate::common::{
     constants::responses::MOCK_REFRESH_TOKEN,
     helper::{
         assert_successful_begin_register_response, assert_successful_finish_login_response,
-        assert_successful_finish_register_response, assert_successful_refresh_response,
-        create_auth_service, create_begin_request, create_login_finish_request,
-        create_register_finish_request, get_begin_login_error_test_cases,
-        get_begin_register_error_test_cases, get_finish_login_error_test_cases,
-        get_finish_register_error_test_cases, get_refresh_error_test_cases,
-        run_begin_login_error_test_case, run_begin_register_error_test_case,
-        run_finish_login_error_test_case, run_finish_register_error_test_case,
-        run_refresh_error_test_case,
+        assert_successful_finish_register_response, assert_successful_logout_response,
+        assert_successful_refresh_response, create_auth_service, create_begin_request,
+        create_login_finish_request, create_register_finish_request,
+        get_begin_login_error_test_cases, get_begin_register_error_test_cases,
+        get_finish_login_error_test_cases, get_finish_register_error_test_cases,
+        get_logout_test_cases, get_refresh_error_test_cases, run_begin_login_error_test_case,
+        run_begin_register_error_test_case, run_finish_login_error_test_case,
+        run_finish_register_error_test_case, run_logout_test_case, run_refresh_error_test_case,
     },
 };
 
@@ -104,5 +104,23 @@ async fn refresh_all_error_scenarios() {
     for test_case in &test_cases {
         println!("Running refresh test case: {}", test_case.test_name);
         run_refresh_error_test_case(test_case).await;
+    }
+}
+
+#[tokio::test]
+async fn logout_success() {
+    let auth_service = create_auth_service();
+
+    let result = auth_service.logout(MOCK_REFRESH_TOKEN).await;
+    assert_successful_logout_response(result);
+}
+
+#[tokio::test]
+async fn logout_all_error_scenarios() {
+    let test_cases = get_logout_test_cases();
+
+    for test_case in &test_cases {
+        println!("Running logout test case: {}", test_case.test_name);
+        run_logout_test_case(test_case).await;
     }
 }

--- a/tests/unit/service.rs
+++ b/tests/unit/service.rs
@@ -3,7 +3,8 @@ use rs_passkey_auth::app::AppError;
 use crate::common::helper::{
     assert_successful_begin_register_response, assert_successful_finish_register_response,
     create_auth_service, create_begin_request, create_finish_request,
-    get_begin_register_error_test_cases, get_finish_register_error_test_cases,
+    get_begin_login_error_test_cases, get_begin_register_error_test_cases,
+    get_finish_register_error_test_cases, run_begin_login_error_test_case,
     run_begin_register_error_test_case, run_finish_register_error_test_case,
 };
 
@@ -46,5 +47,26 @@ async fn finish_register_all_error_scenarios() {
     for test_case in &test_cases {
         println!("Running finish_register test case: {}", test_case.test_name);
         run_finish_register_error_test_case(test_case).await;
+    }
+}
+
+#[tokio::test]
+async fn begin_login_success() -> Result<(), AppError> {
+    let auth_service = create_auth_service();
+    let request = create_begin_request();
+
+    let result = auth_service.begin_register(request).await;
+    assert_successful_begin_register_response(result);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn begin_login_all_error_scenarios() {
+    let test_cases = get_begin_login_error_test_cases();
+
+    for test_case in &test_cases {
+        println!("Running begin_login test case: {}", test_case.test_name);
+        run_begin_login_error_test_case(test_case).await;
     }
 }

--- a/tests/unit/service.rs
+++ b/tests/unit/service.rs
@@ -2,8 +2,9 @@ use crate::common::helper::{
     assert_successful_begin_register_response, assert_successful_finish_login_response,
     assert_successful_finish_register_response, create_auth_service, create_begin_request,
     create_login_finish_request, create_register_finish_request, get_begin_login_error_test_cases,
-    get_begin_register_error_test_cases, get_finish_register_error_test_cases,
-    run_begin_login_error_test_case, run_begin_register_error_test_case,
+    get_begin_register_error_test_cases, get_finish_login_error_test_cases,
+    get_finish_register_error_test_cases, run_begin_login_error_test_case,
+    run_begin_register_error_test_case, run_finish_login_error_test_case,
     run_finish_register_error_test_case,
 };
 
@@ -71,4 +72,14 @@ async fn finish_login_success() {
 
     let result = auth_service.finish_login(request).await;
     assert_successful_finish_login_response(result);
+}
+
+#[tokio::test]
+async fn finish_login_all_error_scenarios() {
+    let test_cases = get_finish_login_error_test_cases();
+
+    for test_case in &test_cases {
+        println!("Running finish_login test case: {}", test_case.test_name);
+        run_finish_login_error_test_case(test_case).await;
+    }
 }

--- a/tests/unit/service.rs
+++ b/tests/unit/service.rs
@@ -3,7 +3,8 @@ use rs_passkey_auth::app::AppError;
 use crate::common::helper::{
     assert_successful_begin_register_response, assert_successful_finish_register_response,
     create_auth_service, create_begin_request, create_finish_request,
-    get_begin_register_error_test_cases, run_error_test_case,
+    get_begin_register_error_test_cases, get_finish_register_error_test_cases,
+    run_begin_register_error_test_case, run_finish_register_error_test_case,
 };
 
 #[tokio::test]
@@ -22,8 +23,8 @@ async fn begin_register_all_error_scenarios() {
     let test_cases = get_begin_register_error_test_cases();
 
     for test_case in &test_cases {
-        println!("Running test case: {}", test_case.test_name);
-        run_error_test_case(test_case).await;
+        println!("Running begin_register test case: {}", test_case.test_name);
+        run_begin_register_error_test_case(test_case).await;
     }
 }
 
@@ -33,8 +34,17 @@ async fn finish_register_success() -> Result<(), AppError> {
     let request = create_finish_request();
 
     let result = auth_service.finish_register(request).await;
-    println!("Result: {:?}", result);
     assert_successful_finish_register_response(result);
 
     Ok(())
+}
+
+#[tokio::test]
+async fn finish_register_all_error_scenarios() {
+    let test_cases = get_finish_register_error_test_cases();
+
+    for test_case in &test_cases {
+        println!("Running finish_register test case: {}", test_case.test_name);
+        run_finish_register_error_test_case(test_case).await;
+    }
 }

--- a/tests/unit/service.rs
+++ b/tests/unit/service.rs
@@ -1,17 +1,27 @@
+macro_rules! run_test_cases {
+    ($test_cases:expr, $test_name:expr, $test_runner:expr) => {
+        for test_case in &$test_cases {
+            println!("Running {} test case: {}", $test_name, test_case.test_name);
+            $test_runner(test_case).await;
+        }
+    };
+}
+
 use crate::common::{
     constants::responses::MOCK_REFRESH_TOKEN,
     helper::{
-        assert_successful_begin_register_response, assert_successful_finish_login_response,
-        assert_successful_finish_register_response, assert_successful_healthy_response,
-        assert_successful_logout_response, assert_successful_refresh_response,
-        assert_unhealthy_health_response, create_auth_service, create_auth_service_both_unhealthy,
-        create_auth_service_db_unhealthy, create_auth_service_redis_unhealthy,
-        create_begin_request, create_login_finish_request, create_register_finish_request,
-        get_begin_login_error_test_cases, get_begin_register_error_test_cases,
-        get_finish_login_error_test_cases, get_finish_register_error_test_cases,
-        get_logout_test_cases, get_refresh_error_test_cases, run_begin_login_error_test_case,
-        run_begin_register_error_test_case, run_finish_login_error_test_case,
-        run_finish_register_error_test_case, run_logout_test_case, run_refresh_error_test_case,
+        assert_successful_begin_login_response, assert_successful_begin_register_response,
+        assert_successful_finish_login_response, assert_successful_finish_register_response,
+        assert_successful_healthy_response, assert_successful_logout_response,
+        assert_successful_refresh_response, assert_unhealthy_health_response, create_auth_service,
+        create_auth_service_both_unhealthy, create_auth_service_db_unhealthy,
+        create_auth_service_redis_unhealthy, create_begin_request, create_login_finish_request,
+        create_register_finish_request, get_begin_login_error_test_cases,
+        get_begin_register_error_test_cases, get_finish_login_error_test_cases,
+        get_finish_register_error_test_cases, get_logout_test_cases, get_refresh_error_test_cases,
+        run_begin_login_error_test_case, run_begin_register_error_test_case,
+        run_finish_login_error_test_case, run_finish_register_error_test_case,
+        run_logout_test_case, run_refresh_error_test_case,
     },
 };
 
@@ -27,11 +37,11 @@ async fn begin_register_success() {
 #[tokio::test]
 async fn begin_register_all_error_scenarios() {
     let test_cases = get_begin_register_error_test_cases();
-
-    for test_case in &test_cases {
-        println!("Running begin_register test case: {}", test_case.test_name);
-        run_begin_register_error_test_case(test_case).await;
-    }
+    run_test_cases!(
+        test_cases,
+        "begin_register",
+        run_begin_register_error_test_case
+    );
 }
 
 #[tokio::test]
@@ -46,11 +56,11 @@ async fn finish_register_success() {
 #[tokio::test]
 async fn finish_register_all_error_scenarios() {
     let test_cases = get_finish_register_error_test_cases();
-
-    for test_case in &test_cases {
-        println!("Running finish_register test case: {}", test_case.test_name);
-        run_finish_register_error_test_case(test_case).await;
-    }
+    run_test_cases!(
+        test_cases,
+        "finish_register",
+        run_finish_register_error_test_case
+    );
 }
 
 #[tokio::test]
@@ -58,18 +68,14 @@ async fn begin_login_success() {
     let auth_service = create_auth_service();
     let request = create_begin_request();
 
-    let result = auth_service.begin_register(request).await;
-    assert_successful_begin_register_response(result);
+    let result = auth_service.begin_login(request).await;
+    assert_successful_begin_login_response(result);
 }
 
 #[tokio::test]
 async fn begin_login_all_error_scenarios() {
     let test_cases = get_begin_login_error_test_cases();
-
-    for test_case in &test_cases {
-        println!("Running begin_login test case: {}", test_case.test_name);
-        run_begin_login_error_test_case(test_case).await;
-    }
+    run_test_cases!(test_cases, "begin_login", run_begin_login_error_test_case);
 }
 
 #[tokio::test]
@@ -84,11 +90,7 @@ async fn finish_login_success() {
 #[tokio::test]
 async fn finish_login_all_error_scenarios() {
     let test_cases = get_finish_login_error_test_cases();
-
-    for test_case in &test_cases {
-        println!("Running finish_login test case: {}", test_case.test_name);
-        run_finish_login_error_test_case(test_case).await;
-    }
+    run_test_cases!(test_cases, "finish_login", run_finish_login_error_test_case);
 }
 
 #[tokio::test]
@@ -102,11 +104,7 @@ async fn refresh_success() {
 #[tokio::test]
 async fn refresh_all_error_scenarios() {
     let test_cases = get_refresh_error_test_cases();
-
-    for test_case in &test_cases {
-        println!("Running refresh test case: {}", test_case.test_name);
-        run_refresh_error_test_case(test_case).await;
-    }
+    run_test_cases!(test_cases, "refresh", run_refresh_error_test_case);
 }
 
 #[tokio::test]
@@ -120,11 +118,7 @@ async fn logout_success() {
 #[tokio::test]
 async fn logout_all_error_scenarios() {
     let test_cases = get_logout_test_cases();
-
-    for test_case in &test_cases {
-        println!("Running logout test case: {}", test_case.test_name);
-        run_logout_test_case(test_case).await;
-    }
+    run_test_cases!(test_cases, "logout", run_logout_test_case);
 }
 
 #[tokio::test]
@@ -137,15 +131,17 @@ async fn check_health_success() {
 
 #[tokio::test]
 async fn check_all_unhealthy_scenarios() {
-    let auth_service_db_unhealthy = create_auth_service_db_unhealthy();
-    let result = auth_service_db_unhealthy.check_health().await;
-    assert_unhealthy_health_response(result, "Database");
+    let test_scenarios = vec![
+        (create_auth_service_db_unhealthy(), "Database"),
+        (create_auth_service_redis_unhealthy(), "Redis"),
+        (
+            create_auth_service_both_unhealthy(),
+            "services are unhealthy",
+        ),
+    ];
 
-    let auth_service_redis_unhealthy = create_auth_service_redis_unhealthy();
-    let result = auth_service_redis_unhealthy.check_health().await;
-    assert_unhealthy_health_response(result, "Redis");
-
-    let auth_service_both_unhealthy = create_auth_service_both_unhealthy();
-    let result = auth_service_both_unhealthy.check_health().await;
-    assert_unhealthy_health_response(result, "services are unhealthy");
+    for (auth_service, expected_error_msg) in test_scenarios {
+        let result = auth_service.check_health().await;
+        assert_unhealthy_health_response(result, expected_error_msg);
+    }
 }

--- a/tests/unit/service.rs
+++ b/tests/unit/service.rs
@@ -1,11 +1,16 @@
-use crate::common::helper::{
-    assert_successful_begin_register_response, assert_successful_finish_login_response,
-    assert_successful_finish_register_response, create_auth_service, create_begin_request,
-    create_login_finish_request, create_register_finish_request, get_begin_login_error_test_cases,
-    get_begin_register_error_test_cases, get_finish_login_error_test_cases,
-    get_finish_register_error_test_cases, run_begin_login_error_test_case,
-    run_begin_register_error_test_case, run_finish_login_error_test_case,
-    run_finish_register_error_test_case,
+use crate::common::{
+    constants::responses::MOCK_REFRESH_TOKEN,
+    helper::{
+        assert_successful_begin_register_response, assert_successful_finish_login_response,
+        assert_successful_finish_register_response, assert_successful_refresh_response,
+        create_auth_service, create_begin_request, create_login_finish_request,
+        create_register_finish_request, get_begin_login_error_test_cases,
+        get_begin_register_error_test_cases, get_finish_login_error_test_cases,
+        get_finish_register_error_test_cases, get_refresh_error_test_cases,
+        run_begin_login_error_test_case, run_begin_register_error_test_case,
+        run_finish_login_error_test_case, run_finish_register_error_test_case,
+        run_refresh_error_test_case,
+    },
 };
 
 #[tokio::test]
@@ -81,5 +86,23 @@ async fn finish_login_all_error_scenarios() {
     for test_case in &test_cases {
         println!("Running finish_login test case: {}", test_case.test_name);
         run_finish_login_error_test_case(test_case).await;
+    }
+}
+
+#[tokio::test]
+async fn refresh_success() {
+    let auth_service = create_auth_service();
+
+    let result = auth_service.refresh(MOCK_REFRESH_TOKEN).await;
+    assert_successful_refresh_response(result);
+}
+
+#[tokio::test]
+async fn refresh_all_error_scenarios() {
+    let test_cases = get_refresh_error_test_cases();
+
+    for test_case in &test_cases {
+        println!("Running refresh test case: {}", test_case.test_name);
+        run_refresh_error_test_case(test_case).await;
     }
 }

--- a/tests/unit/service.rs
+++ b/tests/unit/service.rs
@@ -1,22 +1,19 @@
-use rs_passkey_auth::app::AppError;
-
 use crate::common::helper::{
-    assert_successful_begin_register_response, assert_successful_finish_register_response,
-    create_auth_service, create_begin_request, create_finish_request,
-    get_begin_login_error_test_cases, get_begin_register_error_test_cases,
-    get_finish_register_error_test_cases, run_begin_login_error_test_case,
-    run_begin_register_error_test_case, run_finish_register_error_test_case,
+    assert_successful_begin_register_response, assert_successful_finish_login_response,
+    assert_successful_finish_register_response, create_auth_service, create_begin_request,
+    create_login_finish_request, create_register_finish_request, get_begin_login_error_test_cases,
+    get_begin_register_error_test_cases, get_finish_register_error_test_cases,
+    run_begin_login_error_test_case, run_begin_register_error_test_case,
+    run_finish_register_error_test_case,
 };
 
 #[tokio::test]
-async fn begin_register_success() -> Result<(), AppError> {
+async fn begin_register_success() {
     let auth_service = create_auth_service();
     let request = create_begin_request();
 
     let result = auth_service.begin_register(request).await;
     assert_successful_begin_register_response(result);
-
-    Ok(())
 }
 
 #[tokio::test]
@@ -30,14 +27,12 @@ async fn begin_register_all_error_scenarios() {
 }
 
 #[tokio::test]
-async fn finish_register_success() -> Result<(), AppError> {
+async fn finish_register_success() {
     let auth_service = create_auth_service();
-    let request = create_finish_request();
+    let request = create_register_finish_request();
 
     let result = auth_service.finish_register(request).await;
     assert_successful_finish_register_response(result);
-
-    Ok(())
 }
 
 #[tokio::test]
@@ -51,14 +46,12 @@ async fn finish_register_all_error_scenarios() {
 }
 
 #[tokio::test]
-async fn begin_login_success() -> Result<(), AppError> {
+async fn begin_login_success() {
     let auth_service = create_auth_service();
     let request = create_begin_request();
 
     let result = auth_service.begin_register(request).await;
     assert_successful_begin_register_response(result);
-
-    Ok(())
 }
 
 #[tokio::test]
@@ -69,4 +62,13 @@ async fn begin_login_all_error_scenarios() {
         println!("Running begin_login test case: {}", test_case.test_name);
         run_begin_login_error_test_case(test_case).await;
     }
+}
+
+#[tokio::test]
+async fn finish_login_success() {
+    let auth_service = create_auth_service();
+    let request = create_login_finish_request();
+
+    let result = auth_service.finish_login(request).await;
+    assert_successful_finish_login_response(result);
 }

--- a/tests/unit/service.rs
+++ b/tests/unit/service.rs
@@ -1,7 +1,8 @@
 use rs_passkey_auth::app::AppError;
 
 use crate::common::helper::{
-    assert_successful_begin_register_response, create_auth_service, create_begin_request,
+    assert_successful_begin_register_response, assert_successful_finish_register_response,
+    create_auth_service, create_begin_request, create_finish_request,
     get_begin_register_error_test_cases, run_error_test_case,
 };
 
@@ -24,4 +25,16 @@ async fn begin_register_all_error_scenarios() {
         println!("Running test case: {}", test_case.test_name);
         run_error_test_case(test_case).await;
     }
+}
+
+#[tokio::test]
+async fn finish_register_success() -> Result<(), AppError> {
+    let auth_service = create_auth_service();
+    let request = create_finish_request();
+
+    let result = auth_service.finish_register(request).await;
+    println!("Result: {:?}", result);
+    assert_successful_finish_register_response(result);
+
+    Ok(())
 }

--- a/tests/unit/service.rs
+++ b/tests/unit/service.rs
@@ -1,36 +1,27 @@
-use rs_passkey_auth::{
-    app::AppError,
-    auth::{dto::request::BeginRequest, service::AuthService},
-};
-use url::Url;
-use webauthn_rs::WebauthnBuilder;
+use rs_passkey_auth::app::AppError;
 
-use crate::common::mock::{MockAuthRepository, MockJwtService};
+use crate::common::helper::{
+    assert_successful_begin_register_response, create_auth_service, create_begin_request,
+    get_begin_register_error_test_cases, run_error_test_case,
+};
 
 #[tokio::test]
 async fn begin_register_success() -> Result<(), AppError> {
-    let mock_auth_repo = std::sync::Arc::new(MockAuthRepository);
-    let mock_jwt_service = std::sync::Arc::new(MockJwtService);
-
-    let rp_origin = Url::parse("https://localhost:8080").unwrap();
-    let builder = WebauthnBuilder::new("localhost", &rp_origin).unwrap();
-    let webauthn = builder.build().unwrap();
-
-    let auth_service = AuthService::new(webauthn, mock_auth_repo, mock_jwt_service);
-
-    let request = BeginRequest {
-        username: "test_user".to_string(),
-        role: Some("user".to_string()),
-    };
+    let auth_service = create_auth_service();
+    let request = create_begin_request();
 
     let result = auth_service.begin_register(request).await;
-    assert!(result.is_ok(), "begin_register should succeed");
-    let response = result.unwrap();
-    assert!(
-        !response.session_id.is_empty(),
-        "Session ID should not be empty"
-    );
-    assert!(!response.options.is_null(), "Options should not be null");
+    assert_successful_begin_register_response(result);
 
     Ok(())
+}
+
+#[tokio::test]
+async fn begin_register_all_error_scenarios() {
+    let test_cases = get_begin_register_error_test_cases();
+
+    for test_case in &test_cases {
+        println!("Running test case: {}", test_case.test_name);
+        run_error_test_case(test_case).await;
+    }
 }

--- a/tests/unit/service.rs
+++ b/tests/unit/service.rs
@@ -1,0 +1,36 @@
+use rs_passkey_auth::{
+    app::AppError,
+    auth::{dto::request::BeginRequest, service::AuthService},
+};
+use url::Url;
+use webauthn_rs::WebauthnBuilder;
+
+use crate::common::mock::{MockAuthRepository, MockJwtService};
+
+#[tokio::test]
+async fn begin_register_success() -> Result<(), AppError> {
+    let mock_auth_repo = std::sync::Arc::new(MockAuthRepository);
+    let mock_jwt_service = std::sync::Arc::new(MockJwtService);
+
+    let rp_origin = Url::parse("https://localhost:8080").unwrap();
+    let builder = WebauthnBuilder::new("localhost", &rp_origin).unwrap();
+    let webauthn = builder.build().unwrap();
+
+    let auth_service = AuthService::new(webauthn, mock_auth_repo, mock_jwt_service);
+
+    let request = BeginRequest {
+        username: "test_user".to_string(),
+        role: Some("user".to_string()),
+    };
+
+    let result = auth_service.begin_register(request).await;
+    assert!(result.is_ok(), "begin_register should succeed");
+    let response = result.unwrap();
+    assert!(
+        !response.session_id.is_empty(),
+        "Session ID should not be empty"
+    );
+    assert!(!response.options.is_null(), "Options should not be null");
+
+    Ok(())
+}

--- a/tests/unit/service.rs
+++ b/tests/unit/service.rs
@@ -2,9 +2,11 @@ use crate::common::{
     constants::responses::MOCK_REFRESH_TOKEN,
     helper::{
         assert_successful_begin_register_response, assert_successful_finish_login_response,
-        assert_successful_finish_register_response, assert_successful_logout_response,
-        assert_successful_refresh_response, create_auth_service, create_begin_request,
-        create_login_finish_request, create_register_finish_request,
+        assert_successful_finish_register_response, assert_successful_healthy_response,
+        assert_successful_logout_response, assert_successful_refresh_response,
+        assert_unhealthy_health_response, create_auth_service, create_auth_service_both_unhealthy,
+        create_auth_service_db_unhealthy, create_auth_service_redis_unhealthy,
+        create_begin_request, create_login_finish_request, create_register_finish_request,
         get_begin_login_error_test_cases, get_begin_register_error_test_cases,
         get_finish_login_error_test_cases, get_finish_register_error_test_cases,
         get_logout_test_cases, get_refresh_error_test_cases, run_begin_login_error_test_case,
@@ -123,4 +125,27 @@ async fn logout_all_error_scenarios() {
         println!("Running logout test case: {}", test_case.test_name);
         run_logout_test_case(test_case).await;
     }
+}
+
+#[tokio::test]
+async fn check_health_success() {
+    let auth_service = create_auth_service();
+
+    let result = auth_service.check_health().await;
+    assert_successful_healthy_response(result);
+}
+
+#[tokio::test]
+async fn check_all_unhealthy_scenarios() {
+    let auth_service_db_unhealthy = create_auth_service_db_unhealthy();
+    let result = auth_service_db_unhealthy.check_health().await;
+    assert_unhealthy_health_response(result, "Database");
+
+    let auth_service_redis_unhealthy = create_auth_service_redis_unhealthy();
+    let result = auth_service_redis_unhealthy.check_health().await;
+    assert_unhealthy_health_response(result, "Redis");
+
+    let auth_service_both_unhealthy = create_auth_service_both_unhealthy();
+    let result = auth_service_both_unhealthy.check_health().await;
+    assert_unhealthy_health_response(result, "services are unhealthy");
 }


### PR DESCRIPTION
This pull request refactors the authentication and JWT service layers to use traits for improved abstraction and testability, renames key types for clarity, and updates the repository implementation. It also adds documentation for testing and updates the `.dockerignore` file. The most important changes are grouped below:

**Authentication and JWT Service Refactoring:**

* Introduced new traits `AuthRepository` and `JwtService` in `src/auth/traits.rs` to define interfaces for authentication and JWT operations, enabling easier mocking and future extensibility.
* Refactored `AuthService` in `src/auth/service.rs` to be generic over repository and JWT service implementations, replacing concrete types with trait bounds, and updated method calls to use new trait methods. [[1]](diffhunk://#diff-6546f1a87e3a0fad8c4856e21e2be77dfa3356228b64ae20f59c14dfd50c71a9L23-R42) [[2]](diffhunk://#diff-6546f1a87e3a0fad8c4856e21e2be77dfa3356228b64ae20f59c14dfd50c71a9L147-R150) [[3]](diffhunk://#diff-6546f1a87e3a0fad8c4856e21e2be77dfa3356228b64ae20f59c14dfd50c71a9L171-R171)
* Renamed `AuthRepository` to `Repository` in `src/auth/repo.rs`, made its methods private and implemented the new `AuthRepository` trait for it, centralizing the database logic and aligning with the trait-based design. [[1]](diffhunk://#diff-be43527b0cda6c9b5b9766cfefa71d0ed5de2265cf27113d596d2a67724b999fR10-R76) [[2]](diffhunk://#diff-be43527b0cda6c9b5b9766cfefa71d0ed5de2265cf27113d596d2a67724b999fL32-R85) [[3]](diffhunk://#diff-be43527b0cda6c9b5b9766cfefa71d0ed5de2265cf27113d596d2a67724b999fL68-R121) [[4]](diffhunk://#diff-be43527b0cda6c9b5b9766cfefa71d0ed5de2265cf27113d596d2a67724b999fL80-R133) [[5]](diffhunk://#diff-be43527b0cda6c9b5b9766cfefa71d0ed5de2265cf27113d596d2a67724b999fL112-R165) [[6]](diffhunk://#diff-be43527b0cda6c9b5b9766cfefa71d0ed5de2265cf27113d596d2a67724b999fL147-R200) [[7]](diffhunk://#diff-be43527b0cda6c9b5b9766cfefa71d0ed5de2265cf27113d596d2a67724b999fL165-R218) [[8]](diffhunk://#diff-be43527b0cda6c9b5b9766cfefa71d0ed5de2265cf27113d596d2a67724b999fL175-R228) [[9]](diffhunk://#diff-be43527b0cda6c9b5b9766cfefa71d0ed5de2265cf27113d596d2a67724b999fL194-R243) [[10]](diffhunk://#diff-be43527b0cda6c9b5b9766cfefa71d0ed5de2265cf27113d596d2a67724b999fL209-L258)
* Renamed `JwtService` to `Jwt` in `src/utils/jwt.rs`, implemented the `JwtService` trait for it, and updated usages throughout the codebase to use the new type and trait methods. [[1]](diffhunk://#diff-ec6f17193d87063819e8124ebdfd67764da3c13065cca429b70d1a2a51d9a98fL20-R24) [[2]](diffhunk://#diff-ec6f17193d87063819e8124ebdfd67764da3c13065cca429b70d1a2a51d9a98fL58-R62) [[3]](diffhunk://#diff-ec6f17193d87063819e8124ebdfd67764da3c13065cca429b70d1a2a51d9a98fL67-R71) [[4]](diffhunk://#diff-ec6f17193d87063819e8124ebdfd67764da3c13065cca429b70d1a2a51d9a98fL101-R105) [[5]](diffhunk://#diff-ec6f17193d87063819e8124ebdfd67764da3c13065cca429b70d1a2a51d9a98fL215-L239)

**App State Updates:**

* Updated `AppState` in `src/app/state.rs` to use the new generic `AuthService<Repository, Jwt>` type and adjusted initialization logic accordingly. [[1]](diffhunk://#diff-fe2ebff4c05d0f2011e0289f1e0cf193e7908cb8685d6a4a72501a204023bc96L8-R15) [[2]](diffhunk://#diff-fe2ebff4c05d0f2011e0289f1e0cf193e7908cb8685d6a4a72501a204023bc96L25-R27)

**Project Structure and Documentation:**

* Added a new `traits` module to `src/auth/mod.rs` for trait definitions.
* Updated `.dockerignore` to ignore the `tests` directory instead of `test`.
* Added a "Testing" section to `README.md` with instructions for running tests locally.

Fixes #1 